### PR TITLE
Add PSSG format notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # F12012TrackEditor
 A tool for editing existing and creating new tracks for F1 2012
-See [docs/file-format-map.md](docs/file-format-map.md) for a description of the included Melbourne track files.
+See [docs/file-format-map.md](docs/file-format-map.md) for a description of the
+included Melbourne track files.
 
 ## Utilities
 
@@ -16,3 +17,31 @@ fully supports RBXML files with the header `1A 22 52 72`.  RBXML files are
 parsed using their string, node and attribute tables to reconstruct the complete
 XML tree.  If the input already contains plain XML (with or without a UTF-8
 BOM) it is returned unchanged.
+
+`pssg_info.py` reads the header of a PSSG archive and shows basic
+information about the file:
+
+```bash
+python3 pssg_info.py melbourne/objects.pssg
+```
+
+## PSSG Format
+
+- Файлы PSSG используются движком EGO как контейнеры для моделей, текстур и анимаций.
+- Заголовок начинается с сигнатуры `PSSG` и трех 32‑битных чисел (размер файла,
+  смещение таблицы строк и смещение корневого узла) в big-endian.
+- После них обычно следуют значения `1` и `7`, одинаковые у всех исследованных архивов.
+- Таблица строк расположена по смещению `0x239`, а корневой узел — по `0x12b`
+  (эти значения совпадали у всех файлов `melbourne/`).
+- Узлы записываются иерархически: длина имени (32 бита), имя в ASCII, затем два
+  32‑битных поля (первое предположительно флаги, второе — число дочерних элементов
+  или атрибутов).
+- Атрибуты ссылаются на строки из таблицы по их индексам. Многие строки содержат
+  названия текстур и мешей вроде `objects.pssg#concrete_green_a_01_d.tga`.
+- Внешнее сжатие отсутствует, все данные хранятся напрямую внутри архива.
+
+Пример запуска утилиты для получения заголовка:
+```bash
+python3 pssg_info.py melbourne/objects.pssg
+python3 pssg_info.py melbourne/route_0/objects.ens
+```

--- a/pssg_info.py
+++ b/pssg_info.py
@@ -1,0 +1,48 @@
+import struct
+import sys
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python3 pssg_info.py <file.pssg>")
+        return
+
+    path = sys.argv[1]
+    with open(path, 'rb') as f:
+        sig = f.read(4)
+        if sig != b'PSSG':
+            print("Invalid signature:", sig)
+            return
+
+        # Read three big-endian 32-bit integers
+        size, str_table_off, root_off = struct.unpack('>III', f.read(12))
+        print(f"File size: {size}")
+        print(f"String table offset: {str_table_off}")
+        print(f"Root node offset: {root_off}")
+
+        # Try to read a few strings from the string table
+        try:
+            f.seek(str_table_off)
+            strings = []
+            for _ in range(5):
+                chunk = []
+                while True:
+                    ch = f.read(1)
+                    if not ch or ch == b'\x00':
+                        break
+                    chunk.append(ch)
+                if not chunk and not ch:
+                    break
+                strings.append(b''.join(chunk).decode('utf-8', errors='replace'))
+                if not ch:
+                    break
+            if strings:
+                print("Example strings:")
+                for s in strings:
+                    print("  " + s)
+        except Exception as e:
+            print("Could not read string table:", e)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- document findings about the PSSG archive layout in README

## Testing
- `python3 pssg_info.py melbourne/objects.pssg | head -n 7`
- `python3 pssg_info.py melbourne/route_0/objects.ens | head -n 7`
