### PR TITLE
Add simple PSSG extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ parsed using their string, node and attribute tables to reconstruct the complete
 XML tree.  If the input already contains plain XML (with or without a UTF-8
 BOM) it is returned unchanged.
 
-`pssg_info.py` reads the header of a PSSG archive and shows basic
-information about the file:
+`pssg_extractor.py` reads a PSSG archive and prints its header along with a
+rough outline of the node hierarchy:
 
 ```bash
-python3 pssg_info.py melbourne/objects.pssg
+python3 pssg_extractor.py melbourne/objects.pssg
 ```
 
 ## PSSG Format
@@ -40,8 +40,29 @@ python3 pssg_info.py melbourne/objects.pssg
   названия текстур и мешей вроде `objects.pssg#concrete_green_a_01_d.tga`.
 - Внешнее сжатие отсутствует, все данные хранятся напрямую внутри архива.
 
-Пример запуска утилиты для получения заголовка:
+Пример запуска утилиты для просмотра архива:
 ```bash
-python3 pssg_info.py melbourne/objects.pssg
-python3 pssg_info.py melbourne/route_0/objects.ens
+python3 pssg_extractor.py melbourne/objects.pssg
+python3 pssg_extractor.py melbourne/route_0/objects.ens
 ```
+
+## Track Data Overview
+
+The `melbourne/` directory contains all resources for the Melbourne circuit and
+illustrates the variety of formats used by the EGO engine:
+
+- Plain XML like `ParcFerme.xml` describe simple object placement.
+- `RacingLine.xml` is a much larger file with settings, corner ranges,
+  suggested gears, apex points and detailed pit-lane nodes.
+- Many `*.xml` files are actually binary BXML variants (e.g. `basewind2.xml`,
+  `weather_fx.xml`) which can be converted with `bxml2xml.py`.
+- Container archives (`*.pssg`, `*.ens`, `*.jpk`) store models, textures and
+  other assets.
+- Additional binary tables include collision meshes (`*.clm`), boundary and
+  reset lines (`*.cqtc`), visibility data (`*.vis`), lookup tables (`*.lut`)
+  and others.
+
+В каталоге находится 61 файл, из них 29 — XML (часть в бинарном формате), а
+остальные представлены PSSG/ENS и несколькими типами BIN/CLM/CQTC.  Полный
+список заголовков приведен в
+[docs/file-format-map.md](docs/file-format-map.md).

--- a/pssg_extractor.py
+++ b/pssg_extractor.py
@@ -2,9 +2,29 @@ import struct
 import sys
 
 
+def read_node(f, indent=0, limit=None):
+    start = f.tell()
+    if limit is not None and start >= limit:
+        return
+
+    try:
+        name_len_data = f.read(4)
+        if len(name_len_data) < 4:
+            return
+        name_len = struct.unpack('>I', name_len_data)[0]
+        name = f.read(name_len).decode('ascii', errors='replace')
+        flags, child_count = struct.unpack('>II', f.read(8))
+        print('  ' * indent + f"{name} (flags={flags}, children={child_count})")
+
+        for _ in range(child_count):
+            read_node(f, indent + 1, limit)
+    except Exception as e:
+        print('Error reading node at', hex(start), e)
+
+
 def main():
     if len(sys.argv) != 2:
-        print("Usage: python3 pssg_info.py <file.pssg>")
+        print("Usage: python3 pssg_extractor.py <file.pssg>")
         return
 
     path = sys.argv[1]
@@ -20,7 +40,6 @@ def main():
         print(f"String table offset: {str_table_off}")
         print(f"Root node offset: {root_off}")
 
-        # Try to read a few strings from the string table
         try:
             f.seek(str_table_off)
             strings = []
@@ -42,6 +61,10 @@ def main():
                     print("  " + s)
         except Exception as e:
             print("Could not read string table:", e)
+
+        print("\nNode hierarchy:")
+        f.seek(root_off)
+        read_node(f, 0, str_table_off)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- rename `pssg_info.py` to `pssg_extractor.py`
- implement naive node reader in new script
- update README documentation for the renamed utility

## Testing
- `python3 -m py_compile bxml2xml.py pssg_extractor.py`