### PR TITLE
Handle truncated nodes in extract_pssg

### DIFF
--- a/extract_pssg.py
+++ b/extract_pssg.py
@@ -5,18 +5,29 @@ from pathlib import Path
 from bxml2xml import bxml_to_xml
 
 
-def read_node(f, depth=0):
+def read_node(f, depth=0, limit=None):
     start = f.tell()
+    if limit is not None and start >= limit:
+        return []
+
     length_data = f.read(4)
     if len(length_data) < 4:
         return []
     name_len = struct.unpack('>I', length_data)[0]
-    name = f.read(name_len).decode('ascii', errors='replace')
-    flags, child_count = struct.unpack('>II', f.read(8))
-    nodes = []
+
+    name_bytes = f.read(name_len)
+    if len(name_bytes) < name_len:
+        return []
+    name = name_bytes.decode('ascii', errors='replace')
+
+    header = f.read(8)
+    if len(header) < 8:
+        return []
+    flags, child_count = struct.unpack('>II', header)
+
+    nodes = [(depth, name, start)]
     for _ in range(child_count):
-        nodes.extend(read_node(f, depth + 1))
-    nodes.append((depth, name, start))
+        nodes.extend(read_node(f, depth + 1, limit))
     return nodes
 
 
@@ -26,7 +37,7 @@ def extract(input_path: Path, out_dir: Path):
             raise ValueError('Not a PSSG file')
         size, str_off, root_off = struct.unpack('>III', f.read(12))
         f.seek(root_off - 2)  # heuristic for root name length
-        nodes = read_node(f)
+        nodes = read_node(f, limit=str_off)
     # Extraction of actual data is not implemented yet
     out_dir.mkdir(parents=True, exist_ok=True)
     outline = ['%s%s' % ('  ' * d, n) for d, n, _ in nodes]


### PR DESCRIPTION
## Summary
- safeguard node reader against truncated data
- stop reading nodes once the start of the string table is reached

## Testing
- `python3 -m py_compile extract_pssg.py`