### PR TITLE
Fix PSSG header parsing

### DIFF
--- a/PssgViewer/PssgArchive.cs
+++ b/PssgViewer/PssgArchive.cs
@@ -14,6 +14,7 @@ namespace PssgViewer
     public class PssgArchive
     {
         public uint Size { get; set; }
+        public uint IndexTableOffset { get; set; }
         public uint StringTableOffset { get; set; }
         public uint RootOffset { get; set; }
         public PssgNode Root { get; set; }
@@ -23,12 +24,18 @@ namespace PssgViewer
         {
             using var fs = File.OpenRead(path);
             var br = new BinaryReader(fs);
-            if (new string(br.ReadChars(4)) != "PSSG")
+            // Read signature as raw bytes to avoid decoding issues with ReadChars
+            var sig = System.Text.Encoding.ASCII.GetString(br.ReadBytes(4));
+            if (sig != "PSSG")
                 throw new InvalidDataException("Invalid PSSG signature");
             var archive = new PssgArchive();
             archive.Size = ReadBEUInt32(br);
+            archive.IndexTableOffset = ReadBEUInt32(br);
             archive.StringTableOffset = ReadBEUInt32(br);
-            archive.RootOffset = ReadBEUInt32(br);
+
+            // In these archives the root node always starts right after the
+            // 0x14-byte header
+            archive.RootOffset = 0x14u;
 
             fs.Seek(archive.RootOffset, SeekOrigin.Begin);
             archive.Root = ReadNode(br, archive.StringTableOffset);

--- a/extract_pssg.py
+++ b/extract_pssg.py
@@ -35,8 +35,8 @@ def extract(input_path: Path, out_dir: Path):
     with input_path.open('rb') as f:
         if f.read(4) != b'PSSG':
             raise ValueError('Not a PSSG file')
-        size, str_off, root_off = struct.unpack('>III', f.read(12))
-        f.seek(root_off - 2)  # heuristic for root name length
+        size, index_off, str_off = struct.unpack('>III', f.read(12))
+        f.seek(0x14)
         nodes = read_node(f, limit=str_off)
     # Extraction of actual data is not implemented yet
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/pssg.py
+++ b/pssg.py
@@ -99,6 +99,7 @@ def _encode_string_table(strings: List[str]) -> bytes:
 @dataclass
 class PSSGArchive:
     size: int
+    index_table_offset: int
     string_table_offset: int
     root_offset: int
     root: PSSGNode
@@ -109,24 +110,27 @@ class PSSGArchive:
         with path.open("rb") as f:
             if f.read(4) != b"PSSG":
                 raise ValueError("Invalid PSSG signature")
-            size, str_off, root_off = struct.unpack(">III", f.read(12))
+            size, index_off, str_off = struct.unpack(">III", f.read(12))
+            root_off = 0x14  # header size with unknown field
             f.seek(root_off)
             root = _read_node(f, str_off)
             f.seek(str_off)
             strings = _read_string_table(f)
-        return cls(size, str_off, root_off, root, strings)
+        return cls(size, index_off, str_off, root_off, root, strings)
 
     def save(self, path: Path) -> None:
         node_blob = _encode_node(self.root)
-        root_off = 0x10  # header size
+        root_off = 0x14  # header size with unknown field
         str_off = root_off + len(node_blob)
         str_blob = _encode_string_table(self.strings)
         size = str_off + len(str_blob)
+        index_off = str_off  # we don't emit index data
         with path.open("wb") as f:
             f.write(b"PSSG")
-            f.write(struct.pack(">III", size, str_off, root_off))
+            f.write(struct.pack(">III", size, index_off, str_off))
             f.write(node_blob)
             f.write(str_blob)
         self.size = size
+        self.index_table_offset = index_off
         self.string_table_offset = str_off
         self.root_offset = root_off

--- a/pssg_extractor.py
+++ b/pssg_extractor.py
@@ -35,7 +35,8 @@ def main():
             return
 
         # Read three big-endian 32-bit integers
-        size, str_table_off, root_off = struct.unpack('>III', f.read(12))
+        size, index_off, str_table_off = struct.unpack('>III', f.read(12))
+        root_off = 0x14
         print(f"File size: {size}")
         print(f"String table offset: {str_table_off}")
         print(f"Root node offset: {root_off}")


### PR DESCRIPTION
## Summary
- handle index table offset field in PSSG header
- root node always begins at 0x14
- adjust Python utilities to match new header format

## Testing
- `python3 -m py_compile pssg.py pssg_viewer.py pssg_extractor.py bxml2xml.py extract_pssg.py`
