### PR TITLE
Auto-convert PSSG files on open

### DIFF
--- a/PssgViewer/MainWindow.xaml.cs
+++ b/PssgViewer/MainWindow.xaml.cs
@@ -77,11 +77,12 @@ namespace PssgViewer
 
                 if (Path.GetExtension(filePath).Equals(".pssg", StringComparison.OrdinalIgnoreCase))
                 {
-                    // Parse binary PSSG and convert to simple XML tree
-                    var archive = PssgArchive.Load(filePath);
-                    XmlElement root = document.CreateElement(archive.Root.Name);
-                    document.AppendChild(root);
-                    BuildXmlFromPssgNode(archive.Root, root, document);
+                    UpdateStatus("Converting PSSG to XML...");
+                    // Convert to XML file then load it
+                    string xmlPath = ConvertPssgToXml(filePath);
+                    document.Load(xmlPath);
+                    // Display resulting XML path in textbox
+                    txtFilePath.Text = xmlPath;
                 }
                 else
                 {
@@ -113,6 +114,20 @@ namespace PssgViewer
                 parent.AppendChild(elem);
                 BuildXmlFromPssgNode(child, elem, doc);
             }
+        }
+
+        private static string ConvertPssgToXml(string pssgPath)
+        {
+            var archive = PssgArchive.Load(pssgPath);
+            XmlDocument doc = new XmlDocument();
+            XmlDeclaration decl = doc.CreateXmlDeclaration("1.0", "utf-8", null);
+            doc.AppendChild(decl);
+            XmlElement root = doc.CreateElement(archive.Root.Name);
+            doc.AppendChild(root);
+            BuildXmlFromPssgNode(archive.Root, root, doc);
+            string xmlPath = System.IO.Path.ChangeExtension(pssgPath, ".xml");
+            doc.Save(xmlPath);
+            return xmlPath;
         }
 
         private void ClearAll()


### PR DESCRIPTION
## Summary
- convert `.pssg` files to `.xml` before loading in the viewer
- add helper to save converted XML

## Testing
- `dotnet --version` *(fails: command not found)*