### PR TITLE
Fix attribute parsing in PSSG parser

### DIFF
--- a/PssgViewer/PssgParser.cs
+++ b/PssgViewer/PssgParser.cs
@@ -182,10 +182,10 @@ namespace PssgViewer.Core
                 else
                 {
                     byte[] buf = br.ReadBytes((int)aValSize);
-                    if (BitConverter.ToUInt32(buf, 0) == aValSize - 4)
+                    if (aValSize >= 4 && BitConverter.ToUInt32(buf, 0) == aValSize - 4)
                         value = Encoding.ASCII.GetString(buf, 4, (int)aValSize - 4);
                     else
-                        value = buf; // raw bytes
+                        value = buf; // raw bytes or too small for length prefix
                 }
                 string attrName = schema.AttributeNames.TryGetValue(aId, out var n) ? n : $"ATTR_{aId}";
                 node.Attributes[attrName] = value;


### PR DESCRIPTION
## Summary
- avoid `ArgumentOutOfRangeException` when reading short attribute values

## Testing
- `python3 -m py_compile bxml2xml.py pssg_extractor.py extract_pssg.py pssg.py pssg_viewer.py`
