### PR TITLE
Improve XML export

### DIFF
--- a/PssgViewer/MainWindow.xaml.cs
+++ b/PssgViewer/MainWindow.xaml.cs
@@ -9,6 +9,7 @@ using System.Windows.Media;
 using System.Windows.Media.Media3D;
 using System.Xml;
 using System.Xml.Linq;
+using System.Text;
 using HelixToolkit.Wpf;
 using Microsoft.Win32;
 using PssgViewer.Core;
@@ -124,7 +125,16 @@ namespace PssgViewer
                 string exeDir = AppDomain.CurrentDomain.BaseDirectory;
                 string xmlName = Path.GetFileNameWithoutExtension(pssgPath) + ".xml";
                 string outPath = Path.Combine(exeDir, xmlName);
-                xdoc.Save(outPath);
+
+                var settings = new XmlWriterSettings
+                {
+                    Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                    Indent = false,
+                    NewLineHandling = NewLineHandling.Replace,
+                    NewLineChars = Environment.NewLine
+                };
+                using var writer = XmlWriter.Create(outPath, settings);
+                xdoc.Save(writer);
             }
             catch
             {

--- a/PssgViewer/PssgParser.cs
+++ b/PssgViewer/PssgParser.cs
@@ -88,6 +88,31 @@ namespace PssgViewer.Core
                     }
                     el.Value = string.Join(" ", values.ToArray().Select(v => v.ToString("0.000000000e+000")));
                 }
+                else if (ElementName.Equals("SHADERINPUT", StringComparison.OrdinalIgnoreCase) &&
+                         Attributes.TryGetValue("type", out var typ) &&
+                         string.Equals(typ?.ToString(), "constant", StringComparison.OrdinalIgnoreCase) &&
+                         Attributes.TryGetValue("format", out var fmt) &&
+                         string.Equals(fmt?.ToString(), "float", StringComparison.OrdinalIgnoreCase))
+                {
+                    int count = RawData.Length / 4;
+                    Span<float> values = count <= 16 ? stackalloc float[count] : new float[count];
+                    for (int i = 0; i < count; i++)
+                    {
+                        var slice = RawData.AsSpan(i * 4, 4);
+                        if (BitConverter.IsLittleEndian)
+                        {
+                            Span<byte> tmp = stackalloc byte[4];
+                            slice.CopyTo(tmp);
+                            tmp.Reverse();
+                            values[i] = BitConverter.ToSingle(tmp);
+                        }
+                        else
+                        {
+                            values[i] = BitConverter.ToSingle(slice);
+                        }
+                    }
+                    el.Value = string.Join(" ", values.ToArray().Select(v => v.ToString("0.000000000e+000")));
+                }
                 else if (ElementName.Equals("DATABLOCKDATA", StringComparison.OrdinalIgnoreCase))
                 {
                     var sb = new StringBuilder(RawData.Length * 3);


### PR DESCRIPTION
## Summary
- handle SHADERINPUT constant floats to match in-game XML
- save generated XML without BOM and indentation

## Testing
- `python3 -m py_compile bxml2xml.py`
