### PR TITLE
Add async loading and half float conversion

### DIFF
--- a/PssgViewer/BinaryPssgParser.cs
+++ b/PssgViewer/BinaryPssgParser.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Xml;
+
+namespace PssgViewer
+{
+    /// <summary>
+    /// Very small helper that detects binary PSSG files and returns an XmlDocument.
+    /// The actual binary tree parsing is not implemented yet.
+    /// </summary>
+    public static class BinaryPssgParser
+    {
+        public static XmlDocument Parse(string filePath)
+        {
+            // Check for PSSG signature
+            using FileStream fs = File.OpenRead(filePath);
+            byte[] header = new byte[4];
+            if (fs.Read(header, 0, 4) == 4 && Encoding.ASCII.GetString(header) == "PSSG")
+            {
+                // TODO: Implement direct binary parsing of PSSG archives
+                // Placeholder: return null so the caller falls back to XmlDocument.Load
+                return null;
+            }
+
+            return null;
+        }
+    }
+}

--- a/PssgViewer/MainViewModel.cs
+++ b/PssgViewer/MainViewModel.cs
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace PssgViewer
+{
+    /// <summary>
+    /// Simple view model used to load files asynchronously.
+    /// </summary>
+    public class MainViewModel
+    {
+        public async Task<XmlDocument> LoadFileAsync(string filePath)
+        {
+            return await Task.Run(() =>
+            {
+                // Try to parse the file directly if it's a binary PSSG
+                XmlDocument? doc = BinaryPssgParser.Parse(filePath);
+                if (doc != null)
+                    return doc;
+
+                // Fall back to regular XML loading
+                XmlDocument xml = new XmlDocument();
+                xml.Load(filePath);
+                return xml;
+            });
+        }
+    }
+}

--- a/PssgViewer/MainWindow.xaml.cs
+++ b/PssgViewer/MainWindow.xaml.cs
@@ -8,6 +8,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Media3D;
 using System.Xml;
+using System.Threading.Tasks;
 using HelixToolkit.Wpf;
 using Microsoft.Win32;
 // Use aliases to differentiate between the ambiguous types
@@ -29,6 +30,9 @@ namespace PssgViewer
         private Dictionary<string, string> renderSourceMap = new Dictionary<string, string>();
         private Dictionary<string, string> segmentMap = new Dictionary<string, string>();
 
+        // View model used for asynchronous loading
+        private readonly MainViewModel viewModel = new MainViewModel();
+
         // Track current camera state to lock roll
         private WinVector cameraUpDirection = new WinVector(0, 0, 1);
 
@@ -39,11 +43,12 @@ namespace PssgViewer
         public MainWindow()
         {
             InitializeComponent();
+            DataContext = viewModel;
         }
 
         #region File Operations
 
-        private void OpenFile_Click(object sender, RoutedEventArgs e)
+        private async void OpenFile_Click(object sender, RoutedEventArgs e)
         {
             var dialog = new OpenFileDialog
             {
@@ -57,7 +62,7 @@ namespace PssgViewer
                 {
                     string filePath = dialog.FileName;
                     txtFilePath.Text = filePath;
-                    LoadPssgFile(filePath);
+                    await LoadPssgFileAsync(filePath);
                 }
                 catch (Exception ex)
                 {
@@ -66,16 +71,22 @@ namespace PssgViewer
             }
         }
 
-        private void LoadPssgFile(string filePath)
+        private async Task LoadPssgFileAsync(string filePath)
+        {
+            // Load document in background
+            XmlDocument document = await viewModel.LoadFileAsync(filePath);
+
+            // Parse and update UI on the dispatcher thread
+            LoadPssgFileInternal(filePath, document);
+        }
+        private void LoadPssgFileInternal(string filePath, XmlDocument document)
         {
             // Reset everything
             ClearAll();
 
             try
             {
-                // Load XML document
-                XmlDocument document = new XmlDocument();
-                document.Load(filePath);
+                // XML document is already loaded
 
                 // Parse content in proper order
                 ParseShaders(document);

--- a/PssgViewer/PssgBinaryReader.cs
+++ b/PssgViewer/PssgBinaryReader.cs
@@ -533,32 +533,16 @@ namespace PssgViewer
 
         private static float HalfToFloat(ushort half)
         {
-            // Extract components
-            int sign = (half >> 15) & 0x1;
-            int exp = (half >> 10) & 0x1F;
-            int mantissa = half & 0x3FF;
-
-            // Handle special cases
-            if (exp == 0)
+            // Use the built-in System.Half struct for conversion
+            try
             {
-                if (mantissa == 0)
-                    return sign == 1 ? -0.0f : 0.0f;
-
-                // Denormalized number
-                float num = (float)mantissa / 1024.0f * (float)Math.Pow(2, -14);
-                return sign == 1 ? -num : num;
+                return (float)System.BitConverter.UInt16BitsToHalf(half);
             }
-            else if (exp == 31)
+            catch
             {
-                if (mantissa == 0)
-                    return sign == 1 ? float.NegativeInfinity : float.PositiveInfinity;
-                else
-                    return float.NaN;
+                // Fall back to zero if conversion fails
+                return 0f;
             }
-
-            // Normalized number
-            float value = (1.0f + (float)mantissa / 1024.0f) * (float)Math.Pow(2, exp - 15);
-            return sign == 1 ? -value : value;
         }
 
         #endregion


### PR DESCRIPTION
## Summary
- implement a lightweight `BinaryPssgParser` stub
- add a `MainViewModel` for async file loading
- convert `MainWindow` to use the view model and async `LoadPssgFileAsync`
- rely on `System.BitConverter.UInt16BitsToHalf` in `PssgBinaryReader`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683a3c562d008325aed0175e5129cd19