### PR TITLE
Add placeholder Visual Studio C++ project

### DIFF
--- a/PSSGEditorCPP/MainForm.cpp
+++ b/PSSGEditorCPP/MainForm.cpp
@@ -1,0 +1,45 @@
+#include "MainForm.h"
+#include "PSSGParser.h"
+#include "PSSGWriter.h"
+#include <msclr/marshal_cppstd.h>
+
+MainForm::MainForm() {
+    this->Text = "PSSG Editor";
+    this->Width = 800;
+    this->Height = 600;
+
+    MenuStrip^ menu = gcnew MenuStrip();
+    ToolStripMenuItem^ fileMenu = gcnew ToolStripMenuItem("File");
+    ToolStripMenuItem^ openItem = gcnew ToolStripMenuItem("Open");
+    ToolStripMenuItem^ saveItem = gcnew ToolStripMenuItem("Save As");
+    openItem->Click += gcnew EventHandler(this, &MainForm::OnOpen);
+    saveItem->Click += gcnew EventHandler(this, &MainForm::OnSave);
+    fileMenu->DropDownItems->Add(openItem);
+    fileMenu->DropDownItems->Add(saveItem);
+    menu->Items->Add(fileMenu);
+    this->MainMenuStrip = menu;
+    this->Controls->Add(menu);
+
+    treeView = gcnew TreeView();
+    treeView->Dock = DockStyle::Fill;
+    this->Controls->Add(treeView);
+}
+
+void MainForm::OnOpen(Object^ sender, EventArgs^ e) {
+    OpenFileDialog^ dlg = gcnew OpenFileDialog();
+    dlg->Filter = "PSSG files (*.pssg)|*.pssg|All files (*.*)|*.*";
+    if (dlg->ShowDialog() == System::Windows::Forms::DialogResult::OK) {
+        PSSGParser parser(msclr::interop::marshal_as<std::string>(dlg->FileName));
+        PSSGNode root = parser.Parse();
+        treeView->Nodes->Clear();
+        treeView->Nodes->Add(gcnew String(root.name.c_str()));
+    }
+}
+
+void MainForm::OnSave(Object^ sender, EventArgs^ e) {
+    SaveFileDialog^ dlg = gcnew SaveFileDialog();
+    dlg->Filter = "PSSG files (*.pssg)|*.pssg";
+    if (dlg->ShowDialog() == System::Windows::Forms::DialogResult::OK) {
+        // TODO: save current tree
+    }
+}

--- a/PSSGEditorCPP/MainForm.h
+++ b/PSSGEditorCPP/MainForm.h
@@ -1,0 +1,13 @@
+#pragma once
+
+using namespace System;
+using namespace System::Windows::Forms;
+
+ref class MainForm : public Form {
+public:
+    MainForm();
+private:
+    void OnOpen(Object^ sender, EventArgs^ e);
+    void OnSave(Object^ sender, EventArgs^ e);
+    TreeView^ treeView;
+};

--- a/PSSGEditorCPP/PSSGEditorCPP.vcxproj
+++ b/PSSGEditorCPP/PSSGEditorCPP.vcxproj
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{01234567-89AB-CDEF-0123-456789ABCDEF}</ProjectGuid>
+    <Keyword>ManagedCProj</Keyword>
+    <RootNamespace>PSSGEditorCPP</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CLRSupport>true</CLRSupport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CLRSupport>true</CLRSupport>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ClCompile Include="Program.cpp" />
+    <ClCompile Include="MainForm.cpp" />
+    <ClCompile Include="PSSGParser.cpp" />
+    <ClCompile Include="PSSGWriter.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="MainForm.h" />
+    <ClInclude Include="PSSGNode.h" />
+    <ClInclude Include="PSSGParser.h" />
+    <ClInclude Include="PSSGWriter.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/PSSGEditorCPP/PSSGNode.h
+++ b/PSSGEditorCPP/PSSGNode.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+struct PSSGNode {
+    std::string name;
+    std::unordered_map<std::string, std::vector<unsigned char>> attributes;
+    std::vector<PSSGNode> children;
+    std::vector<unsigned char> data;
+};

--- a/PSSGEditorCPP/PSSGParser.cpp
+++ b/PSSGEditorCPP/PSSGParser.cpp
@@ -1,0 +1,19 @@
+#include "PSSGParser.h"
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <zlib.h>
+
+PSSGParser::PSSGParser(const std::string& path) : path_(path) {}
+
+PSSGNode PSSGParser::Parse() {
+    // TODO: implement full parser; placeholder loads empty root
+    PSSGNode root;
+    root.name = "Root";
+    return root;
+}
+
+PSSGNode PSSGParser::ReadNode(std::istream& stream) {
+    // TODO: implement
+    return PSSGNode();
+}

--- a/PSSGEditorCPP/PSSGParser.h
+++ b/PSSGEditorCPP/PSSGParser.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "PSSGNode.h"
+#include <string>
+
+class PSSGParser {
+public:
+    PSSGParser(const std::string& path);
+    PSSGNode Parse();
+private:
+    PSSGNode ReadNode(std::istream& stream);
+    std::string path_;
+};

--- a/PSSGEditorCPP/PSSGWriter.cpp
+++ b/PSSGEditorCPP/PSSGWriter.cpp
@@ -1,0 +1,14 @@
+#include "PSSGWriter.h"
+#include <fstream>
+
+PSSGWriter::PSSGWriter(const PSSGNode& root) : root_(root) {}
+
+void PSSGWriter::Save(const std::string& path) {
+    std::ofstream file(path, std::ios::binary);
+    if(!file) return; // TODO: error handling
+    // TODO: implement full writer
+}
+
+void PSSGWriter::WriteNode(std::ostream& stream, const PSSGNode& node) {
+    // TODO: implement
+}

--- a/PSSGEditorCPP/PSSGWriter.h
+++ b/PSSGEditorCPP/PSSGWriter.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "PSSGNode.h"
+#include <string>
+
+class PSSGWriter {
+public:
+    PSSGWriter(const PSSGNode& root);
+    void Save(const std::string& path);
+private:
+    void WriteNode(std::ostream& stream, const PSSGNode& node);
+    PSSGNode root_;
+};

--- a/PSSGEditorCPP/Program.cpp
+++ b/PSSGEditorCPP/Program.cpp
@@ -1,0 +1,13 @@
+#include "MainForm.h"
+#include <Windows.h>
+
+using namespace System;
+using namespace System::Windows::Forms;
+
+[STAThread]
+int main(array<String^>^ args) {
+    Application::EnableVisualStyles();
+    Application::SetCompatibleTextRenderingDefault(false);
+    Application::Run(gcnew MainForm());
+    return 0;
+}


### PR DESCRIPTION
## Summary
- create `PSSGEditorCPP` with a placeholder Visual Studio project targeting C++/CLI
- add minimal forms-based GUI skeleton and parser/writer stubs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683cf57900548325a686bd9c859d35a9