### PR TITLE
Improve DataGrid editing UX

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -60,10 +60,18 @@
                       SelectionUnit="Cell"
                       PreviewMouseLeftButtonDown="AttributesDataGrid_PreviewMouseLeftButtonDown"
                       PreviewKeyDown="AttributesDataGrid_PreviewKeyDown"
+                      PreparingCellForEdit="AttributesDataGrid_PreparingCellForEdit"
                       Sorting="AttributesDataGrid_Sorting"
                       Background="Gray"
                       BorderThickness="0"
-                      BorderBrush="Transparent">
+                      BorderBrush="Transparent"
+                      FocusVisualStyle="{x:Null}">
+                <DataGrid.Resources>
+                    <Style TargetType="DataGridCell">
+                        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+                        <Setter Property="BorderThickness" Value="0" />
+                    </Style>
+                </DataGrid.Resources>
                 <DataGrid.Columns>
                     <!-- Столбец «Attribute» с серым фоном и синим выделением -->
                     <DataGridTextColumn Header="Attribute"
@@ -72,7 +80,7 @@
                                         IsReadOnly="True"
                                         Width="2*">
                         <DataGridTextColumn.CellStyle>
-                            <Style TargetType="DataGridCell">
+                            <Style TargetType="DataGridCell" BasedOn="{StaticResource {x:Type DataGridCell}}">
                                 <Setter Property="Background" Value="#EEEEEE" />
                                 <Style.Triggers>
                                     <Trigger Property="IsSelected" Value="True">

--- a/PSSG Editor/MainWindow.xaml.cs
+++ b/PSSG Editor/MainWindow.xaml.cs
@@ -25,6 +25,10 @@ namespace PSSGEditor
         private string savedSortMember = null;
         private ListSortDirection? savedSortDirection = null;
 
+        // Для установки каретки после двойного клика
+        private Point? pendingCaretPoint = null;
+        private DataGridCell pendingCaretCell = null;
+
         public MainWindow()
         {
             InitializeComponent();
@@ -432,8 +436,16 @@ namespace PSSGEditor
         private void AttributesDataGrid_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
             var depObj = (DependencyObject)e.OriginalSource;
-            while (depObj != null && !(depObj is DataGridCell))
+            while (depObj != null && depObj is not DataGridCell)
                 depObj = VisualTreeHelper.GetParent(depObj);
+
+            if (depObj == null)
+            {
+                // Клик не по ячейке – снимаем выделение
+                AttributesDataGrid.UnselectAllCells();
+                Keyboard.ClearFocus();
+                return;
+            }
 
             if (depObj is DataGridCell cell)
             {
@@ -482,6 +494,10 @@ namespace PSSGEditor
                     }
                 }
 
+                // Запомним позицию двойного клика для установки каретки
+                pendingCaretPoint = e.GetPosition(cell);
+                pendingCaretCell = cell;
+
                 // 2) Снимаем текущее выделение и переводим на эту же ячейку, но в режим редактирования
                 AttributesDataGrid.UnselectAllCells();
                 var cellInfo = new DataGridCellInfo(cell.DataContext, cell.Column);
@@ -508,6 +524,22 @@ namespace PSSGEditor
                     {
                         sv.ScrollToVerticalOffset(savedVerticalOffset);
                     }
+
+                    // Если запомнили точку двойного клика – ставим каретку туда
+                    if (pendingCaretPoint.HasValue && pendingCaretCell != null)
+                    {
+                        Point pt = pendingCaretCell.TranslatePoint(pendingCaretPoint.Value, tb);
+                        int charIndex = tb.GetCharacterIndexFromPoint(pt, true);
+                        if (charIndex < 0)
+                            charIndex = tb.Text.Length;
+                        tb.CaretIndex = charIndex;
+                        tb.SelectionLength = 0;
+                        pendingCaretPoint = null;
+                        pendingCaretCell = null;
+                    }
+
+                    // Разрешаем клики ставить курсор без выделения
+                    tb.PreviewMouseLeftButtonDown += ValueTextBox_PreviewMouseLeftButtonDown;
                 }
             }
         }
@@ -524,6 +556,13 @@ namespace PSSGEditor
                     AttributesDataGrid.CommitEdit(DataGridEditingUnit.Cell, true);
                     e.Handled = true;
                 }
+            }
+            else if (e.Key == Key.Escape)
+            {
+                AttributesDataGrid.CancelEdit();
+                AttributesDataGrid.UnselectAllCells();
+                Keyboard.ClearFocus();
+                e.Handled = true;
             }
         }
 


### PR DESCRIPTION
## Summary
- clear selection when clicking on empty space or pressing Esc
- remove focus visuals on DataGrid cells
- keep caret position on double-click

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f1bb227bc8325bdb8cb89e6a9e8cb