### PR TITLE
Improve DataGrid editing UX

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -60,10 +60,18 @@
                       SelectionUnit="Cell"
                       PreviewMouseLeftButtonDown="AttributesDataGrid_PreviewMouseLeftButtonDown"
                       PreviewKeyDown="AttributesDataGrid_PreviewKeyDown"
+                      PreparingCellForEdit="AttributesDataGrid_PreparingCellForEdit"
                       Sorting="AttributesDataGrid_Sorting"
                       Background="Gray"
                       BorderThickness="0"
-                      BorderBrush="Transparent">
+                      BorderBrush="Transparent"
+                      FocusVisualStyle="{x:Null}">
+                <DataGrid.Resources>
+                    <Style TargetType="DataGridCell">
+                        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+                        <Setter Property="BorderThickness" Value="0" />
+                    </Style>
+                </DataGrid.Resources>
                 <DataGrid.Columns>
                     <!-- Столбец «Attribute» с серым фоном и синим выделением -->
                     <DataGridTextColumn Header="Attribute"
@@ -72,7 +80,7 @@
                                         IsReadOnly="True"
                                         Width="2*">
                         <DataGridTextColumn.CellStyle>
-                            <Style TargetType="DataGridCell">
+                            <Style TargetType="DataGridCell" BasedOn="{StaticResource {x:Type DataGridCell}}">
                                 <Setter Property="Background" Value="#EEEEEE" />
                                 <Style.Triggers>
                                     <Trigger Property="IsSelected" Value="True">


### PR DESCRIPTION
## Summary
- clear selection when clicking on empty space or pressing Esc
- remove focus visuals on DataGrid cells
- keep caret position on double-click
- ensure selection gains focus when clicking Attribute column
- place caret at the end when double-clicking past the last character

## Testing
- ❌ `dotnet build` (failed to run: `bash: dotnet: command not found`)
- ✅ `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f1bb227bc8325bdb8cb89e6a9e8cb