### PR TITLE
Improve value field editing UX

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -49,9 +49,12 @@
                           Background="LightGray"
                           ShowsPreview="True" />
 
-            <!-- Правая панель: DataGrid без обводки -->
-            <DataGrid Grid.Column="2"
-                      x:Name="AttributesDataGrid"
+            <!-- Правая панель -->
+            <Grid Grid.Column="2"
+                  x:Name="RightPanel"
+                  PreviewMouseLeftButtonDown="RightPanel_PreviewMouseLeftButtonDown">
+                <!-- DataGrid без обводки -->
+                <DataGrid x:Name="AttributesDataGrid"
                       AutoGenerateColumns="False"
                       CanUserAddRows="False"
                       IsReadOnly="False"
@@ -93,11 +96,29 @@
                             </Style>
                         </DataGridTextColumn.CellStyle>
                     </DataGridTextColumn>
-                    <!-- Столбец «Value» -->
-                    <DataGridTextColumn Header="Value"
-                                        Binding="{Binding Value}"
-                                        SortMemberPath="Value"
-                                        Width="3*" />
+                    <!-- Столбец «Value» с переносом строк и прокруткой -->
+                    <DataGridTemplateColumn Header="Value"
+                                            SortMemberPath="Value"
+                                            Width="3*">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                              x:Name="ValueViewer">
+                                    <TextBlock Text="{Binding Value}"
+                                               TextWrapping="Wrap"/>
+                                </ScrollViewer>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                        <DataGridTemplateColumn.CellEditingTemplate>
+                            <DataTemplate>
+                                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                    <TextBox Text="{Binding Value}"
+                                             AcceptsReturn="True"
+                                             TextWrapping="Wrap"/>
+                                </ScrollViewer>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellEditingTemplate>
+                    </DataGridTemplateColumn>
                 </DataGrid.Columns>
                 <DataGrid.CellStyle>
                     <Style TargetType="DataGridCell">
@@ -105,7 +126,8 @@
                                      Handler="AttributesDataGrid_CellMouseDoubleClick" />
                     </Style>
                 </DataGrid.CellStyle>
-            </DataGrid>
+                </DataGrid>
+            </Grid>
         </Grid>
     </DockPanel>
 </Window>

--- a/PSSG Editor/MainWindow.xaml.cs
+++ b/PSSG Editor/MainWindow.xaml.cs
@@ -557,6 +557,8 @@ namespace PSSGEditor
                 if (AttributesDataGrid.CurrentCell.IsValid)
                 {
                     AttributesDataGrid.CommitEdit(DataGridEditingUnit.Cell, true);
+                    AttributesDataGrid.UnselectAllCells();
+                    Keyboard.ClearFocus();
                     e.Handled = true;
                 }
             }
@@ -567,6 +569,24 @@ namespace PSSGEditor
                 Keyboard.ClearFocus();
                 e.Handled = true;
             }
+        }
+
+        /// <summary>
+        /// Клик по правой панели вне DataGrid – завершаем редактирование и снимаем выделение.
+        /// </summary>
+        private void RightPanel_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            var depObj = (DependencyObject)e.OriginalSource;
+            if (FindVisualParent<DataGrid>(depObj) == AttributesDataGrid)
+                return;
+
+            if (AttributesDataGrid.CurrentCell.IsValid)
+            {
+                AttributesDataGrid.CommitEdit(DataGridEditingUnit.Cell, true);
+            }
+
+            AttributesDataGrid.UnselectAllCells();
+            Keyboard.ClearFocus();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- wrap long values and show a scrollbar for value cells
- add panel click handler to end editing
- commit on Enter key press

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.sln' -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f49e87dec83258129e82144401756