### PR TITLE
Improve editing UX and field layout

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -49,9 +49,12 @@
                           Background="LightGray"
                           ShowsPreview="True" />
 
-            <!-- Правая панель: DataGrid без обводки -->
-            <DataGrid Grid.Column="2"
-                      x:Name="AttributesDataGrid"
+            <!-- Правая панель -->
+            <Grid Grid.Column="2"
+                  x:Name="RightPanel"
+                  PreviewMouseLeftButtonDown="RightPanel_PreviewMouseLeftButtonDown">
+                <!-- DataGrid без обводки -->
+                <DataGrid x:Name="AttributesDataGrid"
                       AutoGenerateColumns="False"
                       CanUserAddRows="False"
                       IsReadOnly="False"
@@ -78,7 +81,7 @@
                                         Binding="{Binding Key}"
                                         SortMemberPath="Key"
                                         IsReadOnly="True"
-                                        Width="2*">
+                                        Width="Auto">
                         <DataGridTextColumn.CellStyle>
                             <Style TargetType="DataGridCell" BasedOn="{StaticResource {x:Type DataGridCell}}">
                                 <Setter Property="Background" Value="#EEEEEE" />
@@ -93,11 +96,30 @@
                             </Style>
                         </DataGridTextColumn.CellStyle>
                     </DataGridTextColumn>
-                    <!-- Столбец «Value» -->
-                    <DataGridTextColumn Header="Value"
-                                        Binding="{Binding Value}"
-                                        SortMemberPath="Value"
-                                        Width="3*" />
+                    <!-- Столбец «Value» с переносом строк и прокруткой -->
+                    <DataGridTemplateColumn Header="Value"
+                                            SortMemberPath="Value"
+                                            Width="*">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                              MaxHeight="{Binding ElementName=RightPanel, Path=ActualHeight}">
+                                    <TextBlock Text="{Binding Value}"
+                                               TextWrapping="Wrap"/>
+                                </ScrollViewer>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                        <DataGridTemplateColumn.CellEditingTemplate>
+                            <DataTemplate>
+                                <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                              MaxHeight="{Binding ElementName=RightPanel, Path=ActualHeight}">
+                                    <TextBox Text="{Binding Value}"
+                                             AcceptsReturn="True"
+                                             TextWrapping="Wrap"/>
+                                </ScrollViewer>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellEditingTemplate>
+                    </DataGridTemplateColumn>
                 </DataGrid.Columns>
                 <DataGrid.CellStyle>
                     <Style TargetType="DataGridCell">
@@ -105,7 +127,8 @@
                                      Handler="AttributesDataGrid_CellMouseDoubleClick" />
                     </Style>
                 </DataGrid.CellStyle>
-            </DataGrid>
+                </DataGrid>
+            </Grid>
         </Grid>
     </DockPanel>
 </Window>

--- a/PSSG Editor/MainWindow.xaml.cs
+++ b/PSSG Editor/MainWindow.xaml.cs
@@ -24,6 +24,7 @@ namespace PSSGEditor
         // Для запоминания сортировки
         private string savedSortMember = null;
         private ListSortDirection? savedSortDirection = null;
+        private bool isEditing = false;
 
         // Для установки каретки после двойного клика
         private Point? pendingCaretPoint = null;
@@ -197,11 +198,11 @@ namespace PSSGEditor
             // Если есть Raw-данные
             if (node.Data != null && node.Data.Length > 0)
             {
-                string rawDisplay = BytesToDisplay("__data__", node.Data);
+                string rawDisplay = BytesToDisplay("Raw Data", node.Data);
                 int origLen = node.Data.Length;
                 listForGrid.Add(new AttributeItem
                 {
-                    Key = "__data__",
+                    Key = "Raw Data",
                     Value = rawDisplay,
                     OriginalLength = origLen
                 });
@@ -403,7 +404,7 @@ namespace PSSGEditor
 
             byte[] newBytes;
 
-            if (attrName == "__data__")
+            if (attrName == "Raw Data")
             {
                 newBytes = DisplayToBytes(attrName, newText, item.OriginalLength);
                 currentNode.Data = newBytes;
@@ -424,6 +425,8 @@ namespace PSSGEditor
             // Обновляем OriginalLength и Value для следующего редактирования
             item.OriginalLength = newBytes.Length;
             item.Value = newText;
+
+            isEditing = false;
         }
 
         /// <summary>
@@ -506,6 +509,7 @@ namespace PSSGEditor
                 var cellInfo = new DataGridCellInfo(cell.DataContext, cell.Column);
                 AttributesDataGrid.CurrentCell = cellInfo;
                 AttributesDataGrid.BeginEdit();
+                isEditing = true;
 
                 e.Handled = true;
             }
@@ -518,6 +522,7 @@ namespace PSSGEditor
         {
             if (e.Column.DisplayIndex == 1)
             {
+                isEditing = true;
                 // EditingElement – это уже сгенерированный TextBox
                 if (e.EditingElement is TextBox tb)
                 {
@@ -554,19 +559,45 @@ namespace PSSGEditor
         {
             if (e.Key == Key.Enter)
             {
-                if (AttributesDataGrid.CurrentCell.IsValid)
+                if (isEditing && AttributesDataGrid.CurrentCell.IsValid)
                 {
                     AttributesDataGrid.CommitEdit(DataGridEditingUnit.Cell, true);
+                    AttributesDataGrid.UnselectAllCells();
+                    Keyboard.ClearFocus();
+                    isEditing = false;
                     e.Handled = true;
                 }
             }
             else if (e.Key == Key.Escape)
             {
-                AttributesDataGrid.CancelEdit();
-                AttributesDataGrid.UnselectAllCells();
-                Keyboard.ClearFocus();
-                e.Handled = true;
+                if (isEditing)
+                {
+                    AttributesDataGrid.CancelEdit();
+                    AttributesDataGrid.UnselectAllCells();
+                    Keyboard.ClearFocus();
+                    isEditing = false;
+                    e.Handled = true;
+                }
             }
+        }
+
+        /// <summary>
+        /// Клик по правой панели вне DataGrid – завершаем редактирование и снимаем выделение.
+        /// </summary>
+        private void RightPanel_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            var depObj = (DependencyObject)e.OriginalSource;
+            if (FindVisualParent<DataGrid>(depObj) == AttributesDataGrid)
+                return;
+
+            if (isEditing && AttributesDataGrid.CurrentCell.IsValid)
+            {
+                AttributesDataGrid.CommitEdit(DataGridEditingUnit.Cell, true);
+                isEditing = false;
+            }
+
+            AttributesDataGrid.UnselectAllCells();
+            Keyboard.ClearFocus();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- keep track of editing state to avoid canceling committed edits
- scroll long values within cell and auto-size attribute column
- rename `__data__` attribute to `Raw Data`

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.sln' -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f49e87dec83258129e82144401756