### PR TITLE
Improve grid usability

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -49,9 +49,12 @@
                           Background="LightGray"
                           ShowsPreview="True" />
 
-            <!-- Правая панель: DataGrid без обводки -->
-            <DataGrid Grid.Column="2"
-                      x:Name="AttributesDataGrid"
+            <!-- Правая панель -->
+            <Grid Grid.Column="2"
+                  x:Name="RightPanel"
+                  PreviewMouseLeftButtonDown="RightPanel_PreviewMouseLeftButtonDown">
+                <!-- DataGrid без обводки -->
+                <DataGrid x:Name="AttributesDataGrid"
                       AutoGenerateColumns="False"
                       CanUserAddRows="False"
                       IsReadOnly="False"
@@ -78,7 +81,7 @@
                                         Binding="{Binding Key}"
                                         SortMemberPath="Key"
                                         IsReadOnly="True"
-                                        Width="2*">
+                                        Width="Auto">
                         <DataGridTextColumn.CellStyle>
                             <Style TargetType="DataGridCell" BasedOn="{StaticResource {x:Type DataGridCell}}">
                                 <Setter Property="Background" Value="#EEEEEE" />
@@ -93,11 +96,30 @@
                             </Style>
                         </DataGridTextColumn.CellStyle>
                     </DataGridTextColumn>
-                    <!-- Столбец «Value» -->
-                    <DataGridTextColumn Header="Value"
-                                        Binding="{Binding Value}"
-                                        SortMemberPath="Value"
-                                        Width="3*" />
+                    <!-- Столбец «Value» с переносом строк и прокруткой -->
+                    <DataGridTemplateColumn Header="Value"
+                                            SortMemberPath="Value"
+                                            Width="*">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                              MaxHeight="{Binding ElementName=AttributesDataGrid, Path=ActualHeight}">
+                                    <TextBlock Text="{Binding Value}"
+                                               TextWrapping="Wrap"/>
+                                </ScrollViewer>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                        <DataGridTemplateColumn.CellEditingTemplate>
+                            <DataTemplate>
+                                <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                              MaxHeight="{Binding ElementName=AttributesDataGrid, Path=ActualHeight}">
+                                    <TextBox Text="{Binding Value}"
+                                             AcceptsReturn="True"
+                                             TextWrapping="Wrap"/>
+                                </ScrollViewer>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellEditingTemplate>
+                    </DataGridTemplateColumn>
                 </DataGrid.Columns>
                 <DataGrid.CellStyle>
                     <Style TargetType="DataGridCell">
@@ -105,7 +127,8 @@
                                      Handler="AttributesDataGrid_CellMouseDoubleClick" />
                     </Style>
                 </DataGrid.CellStyle>
-            </DataGrid>
+                </DataGrid>
+            </Grid>
         </Grid>
     </DockPanel>
 </Window>


### PR DESCRIPTION
## Summary
- ensure value cell scrolls within panel bounds
- resize attribute column after loading new data
- keep node tree focused when sorting

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.sln' -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f49e87dec83258129e82144401756