### PR TITLE
Fix large value field display

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -103,7 +103,7 @@
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <ScrollViewer VerticalScrollBarVisibility="Auto"
-                                              MaxHeight="{Binding ElementName=AttributesDataGrid, Path=ActualHeight}">
+                                              MaxHeight="{Binding ElementName=RightPanel, Path=ActualHeight}">
                                     <TextBlock Text="{Binding Value}"
                                                TextWrapping="Wrap"/>
                                 </ScrollViewer>
@@ -112,7 +112,7 @@
                         <DataGridTemplateColumn.CellEditingTemplate>
                             <DataTemplate>
                                 <ScrollViewer VerticalScrollBarVisibility="Auto"
-                                              MaxHeight="{Binding ElementName=AttributesDataGrid, Path=ActualHeight}">
+                                              MaxHeight="{Binding ElementName=RightPanel, Path=ActualHeight}">
                                     <TextBox Text="{Binding Value}"
                                              AcceptsReturn="True"
                                              TextWrapping="Wrap"/>


### PR DESCRIPTION
## Summary
- prevent value cell from stretching the grid by limiting its scroll viewer to the parent panel height

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.csproj' -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6cae27508325a429390e3d8d16dd