### PR TITLE
Fix large attribute row height

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -69,6 +69,14 @@
                       BorderThickness="0"
                       BorderBrush="Transparent"
                       FocusVisualStyle="{x:Null}">
+                <!-- Limit the maximum height of each row so large values don't
+                     expand the entire grid -->
+                <DataGrid.RowStyle>
+                    <Style TargetType="DataGridRow">
+                        <Setter Property="Height" Value="Auto"/>
+                        <Setter Property="MaxHeight" Value="200"/>
+                    </Style>
+                </DataGrid.RowStyle>
                 <DataGrid.Resources>
                     <Style TargetType="DataGridCell">
                         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
@@ -103,7 +111,7 @@
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <ScrollViewer VerticalScrollBarVisibility="Auto"
-                                              MaxHeight="{Binding ElementName=AttributesDataGrid, Path=ActualHeight}">
+                                              MaxHeight="{Binding ElementName=RightPanel, Path=ActualHeight}">
                                     <TextBlock Text="{Binding Value}"
                                                TextWrapping="Wrap"/>
                                 </ScrollViewer>
@@ -112,7 +120,7 @@
                         <DataGridTemplateColumn.CellEditingTemplate>
                             <DataTemplate>
                                 <ScrollViewer VerticalScrollBarVisibility="Auto"
-                                              MaxHeight="{Binding ElementName=AttributesDataGrid, Path=ActualHeight}">
+                                              MaxHeight="{Binding ElementName=RightPanel, Path=ActualHeight}">
                                     <TextBox Text="{Binding Value}"
                                              AcceptsReturn="True"
                                              TextWrapping="Wrap"/>


### PR DESCRIPTION
## Summary
- cap DataGrid row height so huge values won't stretch the grid

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.csproj' -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6cae27508325a429390e3d8d16dd