### PR TITLE
Fix large value row height

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -1,7 +1,11 @@
 ﻿<Window x:Class="PSSGEditor.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:PSSGEditor"
         Title="PromixFlame PSSG Editor" Height="600" Width="900">
+    <Window.Resources>
+        <local:SubtractConverter x:Key="SubtractConverter" />
+    </Window.Resources>
     <DockPanel>
         <!-- Menu с нижним разделителем -->
         <Border DockPanel.Dock="Top" BorderBrush="Black" BorderThickness="0,0,0,1">
@@ -17,7 +21,7 @@
 
         <!-- Строка статуса с верхним разделителем -->
         <Border DockPanel.Dock="Bottom" BorderBrush="Black" BorderThickness="0,1,0,0">
-            <StatusBar>
+            <StatusBar x:Name="MainStatusBar">
                 <StatusBarItem>
                     <TextBlock x:Name="StatusText" Text="Ready" />
                 </StatusBarItem>
@@ -69,6 +73,20 @@
                       BorderThickness="0"
                       BorderBrush="Transparent"
                       FocusVisualStyle="{x:Null}">
+                <!-- Limit row height so the cell content doesn't overlap the status bar -->
+                <DataGrid.RowStyle>
+                    <Style TargetType="DataGridRow">
+                        <Setter Property="Height" Value="Auto" />
+                        <Setter Property="MaxHeight">
+                            <Setter.Value>
+                                <MultiBinding Converter="{StaticResource SubtractConverter}">
+                                    <Binding ElementName="RightPanel" Path="ActualHeight" />
+                                    <Binding ElementName="MainStatusBar" Path="ActualHeight" />
+                                </MultiBinding>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </DataGrid.RowStyle>
                 <DataGrid.Resources>
                     <Style TargetType="DataGridCell">
                         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
@@ -102,8 +120,13 @@
                                             Width="*">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <ScrollViewer VerticalScrollBarVisibility="Auto"
-                                              MaxHeight="{Binding ElementName=AttributesDataGrid, Path=ActualHeight}">
+                                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                    <ScrollViewer.MaxHeight>
+                                        <MultiBinding Converter="{StaticResource SubtractConverter}">
+                                            <Binding ElementName="RightPanel" Path="ActualHeight" />
+                                            <Binding ElementName="MainStatusBar" Path="ActualHeight" />
+                                        </MultiBinding>
+                                    </ScrollViewer.MaxHeight>
                                     <TextBlock Text="{Binding Value}"
                                                TextWrapping="Wrap"/>
                                 </ScrollViewer>
@@ -111,8 +134,13 @@
                         </DataGridTemplateColumn.CellTemplate>
                         <DataGridTemplateColumn.CellEditingTemplate>
                             <DataTemplate>
-                                <ScrollViewer VerticalScrollBarVisibility="Auto"
-                                              MaxHeight="{Binding ElementName=AttributesDataGrid, Path=ActualHeight}">
+                                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                    <ScrollViewer.MaxHeight>
+                                        <MultiBinding Converter="{StaticResource SubtractConverter}">
+                                            <Binding ElementName="RightPanel" Path="ActualHeight" />
+                                            <Binding ElementName="MainStatusBar" Path="ActualHeight" />
+                                        </MultiBinding>
+                                    </ScrollViewer.MaxHeight>
                                     <TextBox Text="{Binding Value}"
                                              AcceptsReturn="True"
                                              TextWrapping="Wrap"/>

--- a/PSSG Editor/SubtractConverter.cs
+++ b/PSSG Editor/SubtractConverter.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace PSSGEditor
+{
+    /// <summary>
+    /// Converter that subtracts the second value from the first.
+    /// Expects two double values and returns the difference.
+    /// </summary>
+    public class SubtractConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values == null || values.Length < 2)
+                return 0d;
+
+            if (values[0] is double a && values[1] is double b)
+                return Math.Max(a - b, 0d);
+
+            double da = 0d, db = 0d;
+            if (values[0] != null)
+                double.TryParse(values[0].ToString(), out da);
+            if (values[1] != null)
+                double.TryParse(values[1].ToString(), out db);
+            return Math.Max(da - db, 0d);
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add SubtractConverter and bind value row max height above the status bar
- register new converter and status bar name
- adjust templates to use the new binding

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.csproj' -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6cae27508325a429390e3d8d16dd