### PR TITLE
Fix PSSG Editor scroll behavior and ESC key

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -120,7 +120,9 @@
                                             Width="*">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                              Focusable="False"
+                                              MouseLeftButtonDown="ValueScrollViewer_MouseLeftButtonDown">
                                     <ScrollViewer.MaxHeight>
                                         <MultiBinding Converter="{StaticResource SubtractConverter}">
                                             <Binding ElementName="RightPanel" Path="ActualHeight" />
@@ -134,7 +136,9 @@
                         </DataGridTemplateColumn.CellTemplate>
                         <DataGridTemplateColumn.CellEditingTemplate>
                             <DataTemplate>
-                                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                              Focusable="False"
+                                              MouseLeftButtonDown="ValueScrollViewer_MouseLeftButtonDown">
                                     <ScrollViewer.MaxHeight>
                                         <MultiBinding Converter="{StaticResource SubtractConverter}">
                                             <Binding ElementName="RightPanel" Path="ActualHeight" />


### PR DESCRIPTION
## Summary
- prevent selection when using scrollbars in Value column
- keep scroll offset when switching to edit mode
- allow Escape key to clear current selection even outside edit mode

## Testing
- `dotnet build "PSSG Editor/PSSG Editor.csproj" -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7dca0b188325966d472183a7d8f8