### PR TITLE
Fix scroll interactions in value cell

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -122,7 +122,7 @@
                             <DataTemplate>
                                 <ScrollViewer VerticalScrollBarVisibility="Auto"
                                               Focusable="False"
-                                              MouseLeftButtonDown="ValueScrollViewer_MouseLeftButtonDown">
+                                              PreviewMouseLeftButtonDown="ValueScrollViewer_PreviewMouseLeftButtonDown">
                                     <ScrollViewer.MaxHeight>
                                         <MultiBinding Converter="{StaticResource SubtractConverter}">
                                             <Binding ElementName="RightPanel" Path="ActualHeight" />
@@ -138,7 +138,7 @@
                             <DataTemplate>
                                 <ScrollViewer VerticalScrollBarVisibility="Auto"
                                               Focusable="False"
-                                              MouseLeftButtonDown="ValueScrollViewer_MouseLeftButtonDown">
+                                              PreviewMouseLeftButtonDown="ValueScrollViewer_PreviewMouseLeftButtonDown">
                                     <ScrollViewer.MaxHeight>
                                         <MultiBinding Converter="{StaticResource SubtractConverter}">
                                             <Binding ElementName="RightPanel" Path="ActualHeight" />
@@ -147,7 +147,10 @@
                                     </ScrollViewer.MaxHeight>
                                     <TextBox Text="{Binding Value}"
                                              AcceptsReturn="True"
-                                             TextWrapping="Wrap"/>
+                                             TextWrapping="Wrap"
+                                             BorderThickness="0"
+                                             Padding="0"
+                                             FocusVisualStyle="{x:Null}"/>
                                 </ScrollViewer>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellEditingTemplate>

--- a/PSSG Editor/MainWindow.xaml.cs
+++ b/PSSG Editor/MainWindow.xaml.cs
@@ -675,7 +675,7 @@ namespace PSSGEditor
             }
         }
 
-        private void ValueScrollViewer_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        private void ValueScrollViewer_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
             var dep = (DependencyObject)e.OriginalSource;
             if (FindVisualParent<ScrollBar>(dep) != null)


### PR DESCRIPTION
## Summary
- prevent value cell selection when clicking scroll bar by handling preview mouse event
- keep editing cell style flat by removing TextBox borders

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f81e207b483258d87b90fb42f605a