### PR TITLE
Fix value cell click editing

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -121,8 +121,7 @@
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
                                 <ScrollViewer VerticalScrollBarVisibility="Auto"
-                                              Focusable="False"
-                                              PreviewMouseLeftButtonDown="ValueScrollViewer_PreviewMouseLeftButtonDown">
+                                              Focusable="False">
                                     <ScrollViewer.MaxHeight>
                                         <MultiBinding Converter="{StaticResource SubtractConverter}">
                                             <Binding ElementName="RightPanel" Path="ActualHeight" />
@@ -137,8 +136,7 @@
                         <DataGridTemplateColumn.CellEditingTemplate>
                             <DataTemplate>
                                 <ScrollViewer VerticalScrollBarVisibility="Auto"
-                                              Focusable="False"
-                                              PreviewMouseLeftButtonDown="ValueScrollViewer_PreviewMouseLeftButtonDown">
+                                              Focusable="False">
                                     <ScrollViewer.MaxHeight>
                                         <MultiBinding Converter="{StaticResource SubtractConverter}">
                                             <Binding ElementName="RightPanel" Path="ActualHeight" />


### PR DESCRIPTION
## Summary
- block unwanted single-click editing in the Value column
- ensure scrollbar clicks and value cell clicks don't leave the cell selected

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.csproj' -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f84fa643883258b6d18f85fa91b23