### PR TITLE
Fix value field selection when using scrollbar

### DIFF
--- a/PSSG Editor/MainWindow.xaml.cs
+++ b/PSSG Editor/MainWindow.xaml.cs
@@ -458,6 +458,18 @@ namespace PSSGEditor
             {
                 // Нажатие на скроллбар не должно приводить к выделению
                 suppressSelection = true;
+                // После обработки события DataGrid может всё же выделить ячейку,
+                // поэтому очищаем выделение асинхронно
+                Dispatcher.BeginInvoke(new Action(() =>
+                {
+                    if (suppressSelection)
+                    {
+                        AttributesDataGrid.UnselectAllCells();
+                        AttributesDataGrid.CurrentCell = new DataGridCellInfo();
+                        Keyboard.ClearFocus();
+                        suppressSelection = false;
+                    }
+                }), DispatcherPriority.Background);
                 return;
             }
             while (depObj != null && depObj is not DataGridCell)
@@ -648,6 +660,7 @@ namespace PSSGEditor
             if (suppressSelection)
             {
                 AttributesDataGrid.UnselectAllCells();
+                AttributesDataGrid.CurrentCell = new DataGridCellInfo();
                 Keyboard.ClearFocus();
                 suppressSelection = false;
             }


### PR DESCRIPTION
## Summary
- prevent value cell from staying selected when clicking its scrollbar
- ensure current cell focus is cleared when selection is suppressed

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.csproj' -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f97466434832594dd248e4ec28516