### PR TITLE
Fix MainWindow.xaml markup

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -120,13 +120,15 @@
                                             Width="*">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
-                    <TextBlock Text="{Binding Value}"
+                                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                    <TextBlock Text="{Binding Value}"
                                                TextWrapping="Wrap"/>
                                 </ScrollViewer>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                         <DataGridTemplateColumn.CellEditingTemplate>
                             <DataTemplate>
+                                <ScrollViewer VerticalScrollBarVisibility="Auto">
                                     <TextBox Text="{Binding Value}"
                                              AcceptsReturn="True"
                                              TextWrapping="Wrap"/>


### PR DESCRIPTION
## Summary
- fix malformed markup in MainWindow.xaml by adding ScrollViewer wrappers

## Testing
- `python3 - <<'PY'
import xml.etree.ElementTree as ET
ET.parse('F12012TrackEditor/PSSG Editor/MainWindow.xaml')
print('Parsed OK')
PY`
- `dotnet build "PSSG Editor/PSSG Editor.csproj" -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9b530b108325b07247e851e93a08