### PR TITLE
Auto-size attribute column in PSSG Editor

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -78,7 +78,7 @@
                                         Binding="{Binding Key}"
                                         SortMemberPath="Key"
                                         IsReadOnly="True"
-                                        Width="2*">
+                                        Width="Auto">
                         <DataGridTextColumn.CellStyle>
                             <Style TargetType="DataGridCell" BasedOn="{StaticResource {x:Type DataGridCell}}">
                                 <Setter Property="Background" Value="#EEEEEE" />


### PR DESCRIPTION
## Summary
- auto size the attribute column to fit its content or header

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.csproj' -nologo` *(fails: command not found)*
- `python -m py_compile pssg_editor.py`

------
https://chatgpt.com/codex/tasks/task_e_683fa20559608325a20eb9418d56c655