### PR TITLE
Auto-shrink attribute column width

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -78,7 +78,7 @@
                                         Binding="{Binding Key}"
                                         SortMemberPath="Key"
                                         IsReadOnly="True"
-                                        Width="2*">
+                                        Width="Auto">
                         <DataGridTextColumn.CellStyle>
                             <Style TargetType="DataGridCell" BasedOn="{StaticResource {x:Type DataGridCell}}">
                                 <Setter Property="Background" Value="#EEEEEE" />

--- a/PSSG Editor/MainWindow.xaml.cs
+++ b/PSSG Editor/MainWindow.xaml.cs
@@ -9,6 +9,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.ComponentModel;
 using System.Linq;
+using System.Windows.Threading;
 
 namespace PSSGEditor
 {
@@ -209,6 +210,7 @@ namespace PSSGEditor
 
             // Даже если список пуст, DataGrid остаётся видим
             AttributesDataGrid.ItemsSource = listForGrid;
+            AdjustAttributeColumnWidth();
 
             // Восстанавливаем сортировку, если была
             if (!string.IsNullOrEmpty(savedSortMember) && savedSortDirection.HasValue)
@@ -424,6 +426,9 @@ namespace PSSGEditor
             // Обновляем OriginalLength и Value для следующего редактирования
             item.OriginalLength = newBytes.Length;
             item.Value = newText;
+
+            // После изменения текста пересчитаем ширину колонки
+            Dispatcher.BeginInvoke(new Action(AdjustAttributeColumnWidth), DispatcherPriority.Background);
         }
 
         /// <summary>
@@ -623,6 +628,18 @@ namespace PSSGEditor
                 if (charIndex < 0 || charIndex >= tb.Text.Length - 1)
                     charIndex = tb.Text.Length;
                 tb.CaretIndex = charIndex;
+            }
+        }
+
+        // Пересчитать ширину первого столбца (Attribute) по содержимому
+        private void AdjustAttributeColumnWidth()
+        {
+            var col = AttributesDataGrid.Columns.FirstOrDefault(c => c.Header?.ToString() == "Attribute");
+            if (col != null)
+            {
+                // Сначала SizeToCells, затем Auto — учитываем и ячейки, и заголовок
+                col.Width = new DataGridLength(1, DataGridLengthUnitType.SizeToCells);
+                col.Width = DataGridLength.Auto;
             }
         }
 


### PR DESCRIPTION
## Summary
- adjust the Attribute column width after data reload or edits so it can shrink when text shortens

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.csproj' -nologo` *(fails: command not found)*
- `python -m py_compile pssg_editor.py`


------
https://chatgpt.com/codex/tasks/task_e_683fa20559608325a20eb9418d56c655