### PR TITLE
Improve value column wrapping and datagrid scroll

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -31,6 +31,9 @@
                 <ColumnDefinition Width="5" />
                 <ColumnDefinition Width="5*" />
             </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
 
             <!-- Левый TreeView без обводки -->
             <TreeView Grid.Column="0"
@@ -50,7 +53,7 @@
                           ShowsPreview="True" />
 
             <!-- Правая панель: DataGrid без обводки -->
-            <DataGrid Grid.Column="2"
+            <DataGrid Grid.Column="2" Grid.Row="0"
                       x:Name="AttributesDataGrid"
                       AutoGenerateColumns="False"
                       CanUserAddRows="False"
@@ -58,6 +61,8 @@
                       HeadersVisibility="Column"
                       RowHeaderWidth="0"
                       SelectionUnit="Cell"
+                      RowHeight="Auto"
+                      ScrollViewer.VerticalScrollBarVisibility="Auto"
                       PreviewMouseLeftButtonDown="AttributesDataGrid_PreviewMouseLeftButtonDown"
                       PreviewKeyDown="AttributesDataGrid_PreviewKeyDown"
                       PreparingCellForEdit="AttributesDataGrid_PreparingCellForEdit"
@@ -97,7 +102,20 @@
                     <DataGridTextColumn Header="Value"
                                         Binding="{Binding Value}"
                                         SortMemberPath="Value"
-                                        Width="3*" />
+                                        Width="3*">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="TextWrapping" Value="Wrap" />
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                        <DataGridTextColumn.EditingElementStyle>
+                            <Style TargetType="TextBox">
+                                <Setter Property="TextWrapping" Value="Wrap" />
+                                <Setter Property="AcceptsReturn" Value="True" />
+                                <Setter Property="VerticalScrollBarVisibility" Value="Auto" />
+                            </Style>
+                        </DataGridTextColumn.EditingElementStyle>
+                    </DataGridTextColumn>
                 </DataGrid.Columns>
                 <DataGrid.CellStyle>
                     <Style TargetType="DataGridCell">


### PR DESCRIPTION
## Summary
- ensure main grid stretches so DataGrid can scroll
- wrap long text in the Value column
- allow editing textbox to wrap and scroll
- enable DataGrid vertical scrolling

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.csproj' -nologo` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fedab84748325b68048395ce2a00c