### PR TITLE
Add wrapping and scroll support for value column

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -65,7 +65,9 @@
                       Background="Gray"
                       BorderThickness="0"
                       BorderBrush="Transparent"
-                      FocusVisualStyle="{x:Null}">
+                      FocusVisualStyle="{x:Null}"
+                      ScrollViewer.VerticalScrollBarVisibility="Auto"
+                      ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                 <DataGrid.Resources>
                     <Style TargetType="DataGridCell">
                         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
@@ -97,7 +99,19 @@
                     <DataGridTextColumn Header="Value"
                                         Binding="{Binding Value}"
                                         SortMemberPath="Value"
-                                        Width="3*" />
+                                        Width="3*">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="TextWrapping" Value="Wrap" />
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                        <DataGridTextColumn.EditingElementStyle>
+                            <Style TargetType="TextBox">
+                                <Setter Property="TextWrapping" Value="Wrap" />
+                                <Setter Property="AcceptsReturn" Value="True" />
+                            </Style>
+                        </DataGridTextColumn.EditingElementStyle>
+                    </DataGridTextColumn>
                 </DataGrid.Columns>
                 <DataGrid.CellStyle>
                     <Style TargetType="DataGridCell">


### PR DESCRIPTION
## Summary
- enable text wrapping in DataGrid's Value column
- show vertical scrollbar when cell content exceeds panel size

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.csproj' -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff6e0aac483259dc9585c7673691a