### PR TITLE
Fix DataGrid height so vertical scroll appears

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -31,6 +31,10 @@
                 <ColumnDefinition Width="5" />
                 <ColumnDefinition Width="5*" />
             </Grid.ColumnDefinitions>
+            <!-- Ограничиваем высоту содержимого одной строкой -->
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
 
             <!-- Левый TreeView без обводки -->
             <TreeView Grid.Column="0"
@@ -65,7 +69,9 @@
                       Background="Gray"
                       BorderThickness="0"
                       BorderBrush="Transparent"
-                      FocusVisualStyle="{x:Null}">
+                      FocusVisualStyle="{x:Null}"
+                      ScrollViewer.VerticalScrollBarVisibility="Auto"
+                      ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                 <DataGrid.Resources>
                     <Style TargetType="DataGridCell">
                         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
@@ -97,7 +103,19 @@
                     <DataGridTextColumn Header="Value"
                                         Binding="{Binding Value}"
                                         SortMemberPath="Value"
-                                        Width="3*" />
+                                        Width="3*">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="TextWrapping" Value="Wrap" />
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                        <DataGridTextColumn.EditingElementStyle>
+                            <Style TargetType="TextBox">
+                                <Setter Property="TextWrapping" Value="Wrap" />
+                                <Setter Property="AcceptsReturn" Value="True" />
+                            </Style>
+                        </DataGridTextColumn.EditingElementStyle>
+                    </DataGridTextColumn>
                 </DataGrid.Columns>
                 <DataGrid.CellStyle>
                     <Style TargetType="DataGridCell">


### PR DESCRIPTION
## Summary
- limit content grid row height so DataGrid doesn't expand beyond the window
- keep vertical scrollbars auto and horizontal disabled

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.csproj' -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff6e0aac483259dc9585c7673691a