### PR TITLE
Add grid layout to limit DataGrid height

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -2,9 +2,15 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="PromixFlame PSSG Editor" Height="600" Width="900">
-    <DockPanel>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
         <!-- Menu с нижним разделителем -->
-        <Border DockPanel.Dock="Top" BorderBrush="Black" BorderThickness="0,0,0,1">
+        <Border Grid.Row="0" BorderBrush="Black" BorderThickness="0,0,0,1">
             <Menu>
                 <MenuItem Header="_File">
                     <MenuItem x:Name="OpenMenuItem" Header="_Open" Click="OpenMenuItem_Click"/>
@@ -16,7 +22,7 @@
         </Border>
 
         <!-- Строка статуса с верхним разделителем -->
-        <Border DockPanel.Dock="Bottom" BorderBrush="Black" BorderThickness="0,1,0,0">
+        <Border Grid.Row="2" BorderBrush="Black" BorderThickness="0,1,0,0">
             <StatusBar>
                 <StatusBarItem>
                     <TextBlock x:Name="StatusText" Text="Ready" />
@@ -65,7 +71,9 @@
                       Background="Gray"
                       BorderThickness="0"
                       BorderBrush="Transparent"
-                      FocusVisualStyle="{x:Null}">
+                      FocusVisualStyle="{x:Null}"
+                      ScrollViewer.VerticalScrollBarVisibility="Auto"
+                      ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                 <DataGrid.Resources>
                     <Style TargetType="DataGridCell">
                         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
@@ -97,7 +105,19 @@
                     <DataGridTextColumn Header="Value"
                                         Binding="{Binding Value}"
                                         SortMemberPath="Value"
-                                        Width="3*" />
+                                        Width="3*">
+                        <DataGridTextColumn.ElementStyle>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="TextWrapping" Value="Wrap" />
+                            </Style>
+                        </DataGridTextColumn.ElementStyle>
+                        <DataGridTextColumn.EditingElementStyle>
+                            <Style TargetType="TextBox">
+                                <Setter Property="TextWrapping" Value="Wrap" />
+                                <Setter Property="AcceptsReturn" Value="True" />
+                            </Style>
+                        </DataGridTextColumn.EditingElementStyle>
+                    </DataGridTextColumn>
                 </DataGrid.Columns>
                 <DataGrid.CellStyle>
                     <Style TargetType="DataGridCell">
@@ -107,5 +127,5 @@
                 </DataGrid.CellStyle>
             </DataGrid>
         </Grid>
-    </DockPanel>
+    </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- restructure the window layout using a root `Grid`
- assign the menu and status bar to fixed rows
- ensure the DataGrid resides in the middle row with wrapping and scrollbars

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.csproj' -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff6e0aac483259dc9585c7673691a