### PR TITLE
Improve PSSG Editor grid interaction

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -84,6 +84,13 @@
                     <Style TargetType="DataGridCell">
                         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
                         <Setter Property="BorderThickness" Value="0" />
+                        <Setter Property="BorderBrush" Value="Transparent" />
+                        <Style.Triggers>
+                            <Trigger Property="IsEditing" Value="True">
+                                <Setter Property="BorderThickness" Value="0" />
+                                <Setter Property="BorderBrush" Value="Transparent" />
+                            </Trigger>
+                        </Style.Triggers>
                     </Style>
                 </DataGrid.Resources>
                 <DataGrid.Columns>
@@ -121,6 +128,10 @@
                             <Style TargetType="TextBox">
                                 <Setter Property="TextWrapping" Value="Wrap" />
                                 <Setter Property="AcceptsReturn" Value="True" />
+                                <Setter Property="BorderThickness" Value="0" />
+                                <Setter Property="Padding" Value="0" />
+                                <Setter Property="Background" Value="Transparent" />
+                                <Setter Property="FocusVisualStyle" Value="{x:Null}" />
                             </Style>
                         </DataGridTextColumn.EditingElementStyle>
                     </DataGridTextColumn>

--- a/PSSG Editor/MainWindow.xaml.cs
+++ b/PSSG Editor/MainWindow.xaml.cs
@@ -30,6 +30,9 @@ namespace PSSGEditor
         private Point? pendingCaretPoint = null;
         private DataGridCell pendingCaretCell = null;
 
+        // Позволяем начинать редактирование только при двойном клике
+        private bool allowEdit = false;
+
         public MainWindow()
         {
             InitializeComponent();
@@ -39,6 +42,10 @@ namespace PSSGEditor
 
             // Запоминаем новые параметры сортировки
             AttributesDataGrid.Sorting += AttributesDataGrid_Sorting;
+
+            // Ограничиваем начало редактирования и скроллим колесиком
+            AttributesDataGrid.BeginningEdit += AttributesDataGrid_BeginningEdit;
+            AttributesDataGrid.PreviewMouseWheel += AttributesDataGrid_PreviewMouseWheel;
 
             // Обработчик PreparingCellForEdit привязан в XAML
         }
@@ -202,7 +209,7 @@ namespace PSSGEditor
                 int origLen = node.Data.Length;
                 listForGrid.Add(new AttributeItem
                 {
-                    Key = "__data__",
+                    Key = "Raw Data",
                     Value = rawDisplay,
                     OriginalLength = origLen
                 });
@@ -405,9 +412,9 @@ namespace PSSGEditor
 
             byte[] newBytes;
 
-            if (attrName == "__data__")
+            if (attrName == "Raw Data")
             {
-                newBytes = DisplayToBytes(attrName, newText, item.OriginalLength);
+                newBytes = DisplayToBytes("__data__", newText, item.OriginalLength);
                 currentNode.Data = newBytes;
             }
             else
@@ -510,7 +517,9 @@ namespace PSSGEditor
                 AttributesDataGrid.UnselectAllCells();
                 var cellInfo = new DataGridCellInfo(cell.DataContext, cell.Column);
                 AttributesDataGrid.CurrentCell = cellInfo;
+                allowEdit = true;
                 AttributesDataGrid.BeginEdit();
+                allowEdit = false;
 
                 e.Handled = true;
             }
@@ -548,7 +557,26 @@ namespace PSSGEditor
 
                     // Разрешаем клики ставить курсор без выделения
                     tb.PreviewMouseLeftButtonDown += ValueTextBox_PreviewMouseLeftButtonDown;
+                    tb.MouseLeftButtonDown += ValueTextBox_MouseLeftButtonDown;
                 }
+            }
+        }
+
+        private void AttributesDataGrid_BeginningEdit(object sender, DataGridBeginningEditEventArgs e)
+        {
+            if (!allowEdit)
+            {
+                e.Cancel = true;
+            }
+        }
+
+        private void AttributesDataGrid_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
+        {
+            var sv = FindVisualParent<ScrollViewer>((DependencyObject)sender);
+            if (sv != null)
+            {
+                sv.ScrollToVerticalOffset(sv.VerticalOffset - e.Delta);
+                e.Handled = true;
             }
         }
 
@@ -629,6 +657,12 @@ namespace PSSGEditor
                     charIndex = tb.Text.Length;
                 tb.CaretIndex = charIndex;
             }
+        }
+
+        private void ValueTextBox_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            // Предотвращаем передачу кликов DataGrid, чтобы повторные клики не вызывали выделение ячейки
+            e.Handled = true;
         }
 
         // Пересчитать ширину первого столбца (Attribute) по содержимому


### PR DESCRIPTION
## Summary
- rename `__data__` attribute row label to `Raw Data`
- disable single-click editing on grid cells
- enable mouse wheel scrolling in the grid
- remove borders while editing
- hide focus outline and prevent cell highlight on additional clicks

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68400b62aaa8832583937148646223bb