### PR TITLE
Fix editor focus and selection issues

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -84,9 +84,11 @@
                     <Style TargetType="DataGridCell">
                         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
                         <Setter Property="BorderThickness" Value="0" />
+                        <Setter Property="BorderBrush" Value="Transparent" />
                         <Style.Triggers>
                             <Trigger Property="IsEditing" Value="True">
                                 <Setter Property="BorderThickness" Value="0" />
+                                <Setter Property="BorderBrush" Value="Transparent" />
                             </Trigger>
                         </Style.Triggers>
                     </Style>
@@ -129,6 +131,7 @@
                                 <Setter Property="BorderThickness" Value="0" />
                                 <Setter Property="Padding" Value="0" />
                                 <Setter Property="Background" Value="Transparent" />
+                                <Setter Property="FocusVisualStyle" Value="{x:Null}" />
                             </Style>
                         </DataGridTextColumn.EditingElementStyle>
                     </DataGridTextColumn>

--- a/PSSG Editor/MainWindow.xaml.cs
+++ b/PSSG Editor/MainWindow.xaml.cs
@@ -557,6 +557,7 @@ namespace PSSGEditor
 
                     // Разрешаем клики ставить курсор без выделения
                     tb.PreviewMouseLeftButtonDown += ValueTextBox_PreviewMouseLeftButtonDown;
+                    tb.MouseLeftButtonDown += ValueTextBox_MouseLeftButtonDown;
                 }
             }
         }
@@ -656,6 +657,12 @@ namespace PSSGEditor
                     charIndex = tb.Text.Length;
                 tb.CaretIndex = charIndex;
             }
+        }
+
+        private void ValueTextBox_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            // Предотвращаем передачу кликов DataGrid, чтобы повторные клики не вызывали выделение ячейки
+            e.Handled = true;
         }
 
         // Пересчитать ширину первого столбца (Attribute) по содержимому


### PR DESCRIPTION
## Summary
- remove focus border around value textbox so wrapping doesn't shift
- stop datagrid from selecting on second click while editing

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.csproj' -v:m` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840155e62f08325a266c961c973084a