### PR TITLE
Fix caret at end and add cell margins

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -90,6 +90,8 @@
                             <Setter Property="FocusVisualStyle" Value="{x:Null}" />
                             <!-- Remove cell border -->
                             <Setter Property="BorderThickness" Value="0" />
+                            <!-- Uniform margin for all cells -->
+                            <Setter Property="Margin" Value="2" />
                             <!-- Handle MouseDoubleClick event -->
                             <EventSetter Event="MouseDoubleClick"
                                          Handler="AttributesDataGrid_CellMouseDoubleClick" />
@@ -136,6 +138,8 @@
                                     <Setter Property="Foreground" Value="Black" />
                                     <Setter Property="Padding" Value="5" />
                                     <Setter Property="BorderThickness" Value="0" />
+                                    <!-- Same margin for cell content -->
+                                    <Setter Property="Margin" Value="2" />
                                     <Style.Triggers>
                                         <Trigger Property="IsSelected" Value="True">
                                             <Setter Property="Background"
@@ -157,6 +161,7 @@
                             <DataGridTextColumn.ElementStyle>
                                 <Style TargetType="TextBlock">
                                     <Setter Property="TextWrapping" Value="Wrap" />
+                                    <Setter Property="Margin" Value="2" />
                                 </Style>
                             </DataGridTextColumn.ElementStyle>
                             <!-- Editing style: remove border, transparent background, no focus rectangle -->
@@ -166,6 +171,7 @@
                                     <Setter Property="AcceptsReturn" Value="True" />
                                     <Setter Property="BorderThickness" Value="0" />
                                     <Setter Property="Padding" Value="0" />
+                                    <Setter Property="Margin" Value="2" />
                                     <Setter Property="Background" Value="Transparent" />
                                     <Setter Property="FocusVisualStyle" Value="{x:Null}" />
                                 </Style>

--- a/PSSG Editor/MainWindow.xaml.cs
+++ b/PSSG Editor/MainWindow.xaml.cs
@@ -280,7 +280,9 @@ namespace PSSGEditor
                     {
                         Point pt = pendingCaretCell.TranslatePoint(pendingCaretPoint.Value, tb);
                         int charIndex = tb.GetCharacterIndexFromPoint(pt, true);
-                        if (charIndex < 0 || charIndex >= tb.Text.Length)
+                        if (charIndex >= tb.Text.Length - 1)
+                            charIndex = tb.Text.Length;
+                        else if (charIndex < 0)
                             charIndex = tb.Text.Length;
                         tb.CaretIndex = charIndex;
                         tb.SelectionLength = 0;


### PR DESCRIPTION
## Summary
- keep caret at end of cell when double clicking near or beyond the last character
- add a small consistent margin for every cell in the attribute table

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.csproj'` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684036b962d48325b63adbe44663a557