### PR TITLE
Fix caret position and cell padding

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -90,6 +90,8 @@
                             <Setter Property="FocusVisualStyle" Value="{x:Null}" />
                             <!-- Remove cell border -->
                             <Setter Property="BorderThickness" Value="0" />
+                            <!-- Consistent padding for all cells -->
+                            <Setter Property="Padding" Value="2" />
                             <!-- Handle MouseDoubleClick event -->
                             <EventSetter Event="MouseDoubleClick"
                                          Handler="AttributesDataGrid_CellMouseDoubleClick" />
@@ -134,7 +136,7 @@
                                 <Style TargetType="DataGridCell">
                                     <Setter Property="Background" Value="#F0F0F0" />
                                     <Setter Property="Foreground" Value="Black" />
-                                    <Setter Property="Padding" Value="5" />
+                                    <Setter Property="Padding" Value="2" />
                                     <Setter Property="BorderThickness" Value="0" />
                                     <Style.Triggers>
                                         <Trigger Property="IsSelected" Value="True">

--- a/PSSG Editor/MainWindow.xaml.cs
+++ b/PSSG Editor/MainWindow.xaml.cs
@@ -280,8 +280,23 @@ namespace PSSGEditor
                     {
                         Point pt = pendingCaretCell.TranslatePoint(pendingCaretPoint.Value, tb);
                         int charIndex = tb.GetCharacterIndexFromPoint(pt, true);
+
+                        // If user double-clicked at or past the end of text,
+                        // GetCharacterIndexFromPoint returns the index of the
+                        // last character. In that case we want to place the
+                        // caret at the very end instead of before the last
+                        // character.
                         if (charIndex < 0 || charIndex >= tb.Text.Length)
+                        {
                             charIndex = tb.Text.Length;
+                        }
+                        else if (charIndex == tb.Text.Length - 1)
+                        {
+                            Rect r = tb.GetRectFromCharacterIndex(charIndex);
+                            if (pt.X >= r.Right)
+                                charIndex = tb.Text.Length;
+                        }
+
                         tb.CaretIndex = charIndex;
                         tb.SelectionLength = 0;
                         pendingCaretPoint = null;


### PR DESCRIPTION
## Summary
- ensure caret moves to end when double-clicking past last character
- add uniform padding for datagrid cells

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840389b14e4832586bf5665b4896f81