### PR TITLE
Improve PSSG editor internals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ PSSG Editor/obj
 __pycache__/
 # Others
 *.cache
+

--- a/PSSG Editor/App.xaml
+++ b/PSSG Editor/App.xaml
@@ -1,5 +1,5 @@
 ﻿<!-- App.xaml -->
-<Application x:Class="PSSG_Editor.App"
+<Application x:Class="PSSGEditor.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              StartupUri="MainWindow.xaml">

--- a/PSSG Editor/MainWindow.xaml.cs
+++ b/PSSG Editor/MainWindow.xaml.cs
@@ -150,15 +150,16 @@ namespace PSSGEditor
             // Fill attributes (Key → Value)
             if (node.Attributes != null && node.Attributes.Count > 0)
             {
-                foreach (var kv in node.Attributes)
+                foreach (var attr in node.Attributes)
                 {
-                    string valDisplay = BytesToDisplay(kv.Key, kv.Value);
-                    int origLen = kv.Value?.Length ?? 0;
+                    string valDisplay = BytesToDisplay(attr.Name, attr.Value);
+                    int origLen = attr.Value?.Length ?? 0;
                     listForGrid.Add(new AttributeItem
                     {
-                        Key = kv.Key,
+                        Key = attr.Name,
                         Value = valDisplay,
-                        OriginalLength = origLen
+                        OriginalLength = origLen,
+                        Source = attr
                     });
                 }
             }
@@ -426,10 +427,10 @@ namespace PSSGEditor
             }
             else
             {
-                if (currentNode.Attributes.ContainsKey(attrName))
+                if (item.Source != null)
                 {
                     newBytes = DisplayToBytes(attrName, newText, item.OriginalLength);
-                    currentNode.Attributes[attrName] = newBytes;
+                    item.Source.Value = newBytes;
                 }
                 else
                 {
@@ -654,6 +655,7 @@ namespace PSSGEditor
             public string Key { get; set; }
             public string Value { get; set; }
             public int OriginalLength { get; set; }
+            public PSSGAttribute Source { get; set; }
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix namespace mismatch in `App.xaml`
- handle PSSG node attributes as ordered list instead of dictionary
- keep reference to each attribute in `MainWindow` for editing
- clean up `.gitignore`

## Testing
- `pytest`
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409dbd3ef08325a4c7b480d4489673