### PR TITLE
fix text selection in value cell

### DIFF
--- a/PSSG Editor/MainWindow.xaml.cs
+++ b/PSSG Editor/MainWindow.xaml.cs
@@ -404,24 +404,27 @@ namespace PSSGEditor
         private void ValueTextBox_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
             var tb = (TextBox)sender;
-            // Always handle the click ourselves, regardless of keyboard focus state
-            e.Handled = true;
-            tb.Focus();
+            if (!tb.IsKeyboardFocusWithin)
+            {
+                // First click when TextBox not focused: place caret manually
+                e.Handled = true;
+                tb.Focus();
 
-            // Compute character index from click position
-            Point clickPos = e.GetPosition(tb);
-            int charIndex = tb.GetCharacterIndexFromPoint(clickPos, false);
-            if (charIndex < 0)
-            {
-                charIndex = tb.Text.Length;
-            }
-            else if (charIndex == tb.Text.Length - 1)
-            {
-                var edge = tb.GetRectFromCharacterIndex(charIndex, true);
-                if (clickPos.X >= edge.X)
+                // Compute character index from click position
+                Point clickPos = e.GetPosition(tb);
+                int charIndex = tb.GetCharacterIndexFromPoint(clickPos, false);
+                if (charIndex < 0)
+                {
                     charIndex = tb.Text.Length;
+                }
+                else if (charIndex == tb.Text.Length - 1)
+                {
+                    var edge = tb.GetRectFromCharacterIndex(charIndex, true);
+                    if (clickPos.X >= edge.X)
+                        charIndex = tb.Text.Length;
+                }
+                tb.CaretIndex = charIndex;
             }
-            tb.CaretIndex = charIndex;
         }
 
         private void AttributesDataGrid_CellEditEnding(object sender, DataGridCellEditEndingEventArgs e)


### PR DESCRIPTION
## Summary
- handle Value text box click only when it doesn't already have focus so normal selection works

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.sln' -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_684194ab0d7883258a104573db4da3b8