### PR TITLE
Fix focus when clicking already editing cell

### DIFF
--- a/PSSG Editor/MainWindow.xaml.cs
+++ b/PSSG Editor/MainWindow.xaml.cs
@@ -370,6 +370,16 @@ namespace PSSGEditor
 
             if (depObj is DataGridCell cell)
             {
+                // When the clicked cell is already in edit mode, do not let the
+                // DataGrid process the click. This prevents the cell from being
+                // re-selected or losing the current caret position while editing.
+                if (cell.IsEditing)
+                {
+                    // Skip custom selection logic when already editing so the
+                    // TextBox inside the cell receives mouse events normally
+                    return;
+                }
+
                 // If click on the "Attribute" column, immediately jump to "Value" cell in the same row
                 if (cell.Column.DisplayIndex == 0)
                 {


### PR DESCRIPTION
## Summary
- prevent DataGrid from taking focus when a cell is already editing by simply returning
- allow text selection to keep working in the editing TextBox

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.csproj' -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841980f6db483258e22909888903333