### PR TITLE
Update DataGrid selection behavior

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -124,7 +124,7 @@
                     </DataGrid.Resources>
 
                     <DataGrid.Columns>
-                        <!-- "Attribute" column: read-only, gray background, blue selection -->
+                        <!-- "Attribute" column: read-only, gray background, no highlight -->
                         <DataGridTextColumn Header="Attribute"
                                             Binding="{Binding Key}"
                                             SortMemberPath="Key"
@@ -137,11 +137,10 @@
                                     <Setter Property="Padding" Value="5" />
                                     <Setter Property="BorderThickness" Value="0" />
                                     <Style.Triggers>
+                                        <!-- Prevent highlight when selected -->
                                         <Trigger Property="IsSelected" Value="True">
-                                            <Setter Property="Background"
-                                                    Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
-                                            <Setter Property="Foreground"
-                                                    Value="{DynamicResource {x:Static SystemColors.HighlightTextBrushKey}}" />
+                                            <Setter Property="Background" Value="#F0F0F0" />
+                                            <Setter Property="Foreground" Value="Black" />
                                         </Trigger>
                                     </Style.Triggers>
                                 </Style>

--- a/PSSG Editor/MainWindow.xaml.cs
+++ b/PSSG Editor/MainWindow.xaml.cs
@@ -376,9 +376,9 @@ namespace PSSGEditor
 
         /// <summary>
         /// Когда клик по DataGrid:
-        /// - При клике вне ячейки: снимаем все выделения и фокус.
-        /// - При клике по столбцу "Attribute" (DisplayIndex == 0): снимаем выделение и фокус, но не переводим в "Value".
-        /// - При клике по "Value": ничего не делаем (редактирование начнётся только от двойного клика).
+        /// - При клике вне ячейки: отменяем редактирование, снимаем все выделения и фокус.
+        /// - При клике по столбцу "Attribute" (DisplayIndex == 0): выделяем соответствующую ячейку "Value".
+        /// - При клике по "Value": ничего не делаем (редактирование начинается только от двойного клика).
         /// </summary>
         private void AttributesDataGrid_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
@@ -388,7 +388,9 @@ namespace PSSGEditor
 
             if (depObj == null)
             {
-                // Клик не по ячейке — снимаем выделение и фокус
+                // Клик не по ячейке — отменяем редактирование и снимаем выделение
+                if (AttributesDataGrid.IsEditing)
+                    AttributesDataGrid.CancelEdit();
                 AttributesDataGrid.UnselectAllCells();
                 Keyboard.ClearFocus();
                 return;
@@ -397,12 +399,18 @@ namespace PSSGEditor
             if (depObj is DataGridCell cell)
             {
                 // Если клик по столбцу "Attribute" (DisplayIndex == 0):
-                // просто очищаем выделение и убираем фокус, без перехода на "Value"
+                // подсвечиваем связанную ячейку "Value" и не даём выделять сам атрибут
                 if (cell.Column.DisplayIndex == 0)
                 {
-                    AttributesDataGrid.UnselectAllCells();
-                    Keyboard.ClearFocus();
-                    e.Handled = true; // предотвращаем переход к следующей обработке
+                    var valueColumn = AttributesDataGrid.Columns.FirstOrDefault(c => c.DisplayIndex == 1);
+                    if (valueColumn != null)
+                    {
+                        AttributesDataGrid.SelectedCells.Clear();
+                        var info = new DataGridCellInfo(cell.DataContext, valueColumn);
+                        AttributesDataGrid.SelectedCells.Add(info);
+                        AttributesDataGrid.CurrentCell = info;
+                    }
+                    e.Handled = true; // предотвращаем выделение атрибута
                 }
                 // Если клик по "Value" и ячейка уже в режиме редактирования,
                 // блокируем стандартную обработку DataGrid, чтобы он не отнимал


### PR DESCRIPTION
## Summary
- keep `Attribute` column cells from highlighting
- select the corresponding value cell when the attribute is clicked
- cancel edit when clicking outside of the grid

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.sln' -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_684204406da883259d49cb94b9c95657