### PR TITLE
Remove DataGrid from main view

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -55,10 +55,11 @@
                           Background="LightGray"
                           ShowsPreview="True" />
 
-            <!-- Right panel: DataGrid inside a ScrollViewer, no outer border -->
+            <!-- Right panel: previously contained a DataGrid. Now only a gray background -->
             <ScrollViewer Grid.Column="2"
                           VerticalScrollBarVisibility="Auto"
-                          HorizontalScrollBarVisibility="Disabled">
+                          HorizontalScrollBarVisibility="Disabled"
+                          Background="Gray">
                 <DataGrid x:Name="AttributesDataGrid"
                           AutoGenerateColumns="False"
                           CanUserAddRows="False"
@@ -75,7 +76,8 @@
                           BorderBrush="Transparent"
                           FocusVisualStyle="{x:Null}"
                           ScrollViewer.VerticalScrollBarVisibility="Disabled"
-                          ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                          ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                          Visibility="Collapsed">
 
                     <!--
                         Common DataGridCell style:


### PR DESCRIPTION
## Summary
- hide the attributes DataGrid so the right side only shows a gray background

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.csproj' -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421f9611988325a677786027bcc343