### PR TITLE
Allow editing raw data

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -99,15 +99,19 @@
                 </DataGrid.CellStyle>
             </DataGrid>
             <!-- Панель Raw Data -->
-            <StackPanel Grid.Column="2" x:Name="RawDataPanel" Visibility="Collapsed">
+            <StackPanel Grid.Column="2"
+                        x:Name="RawDataPanel"
+                        Visibility="Collapsed"
+                        Background="LightGray"
+                        Panel.ZIndex="1">
                 <TextBlock Text="Raw Data" FontWeight="Bold" Margin="5,0,5,5" />
                 <TextBox x:Name="RawDataTextBox"
-                         IsReadOnly="True"
                          AcceptsReturn="True"
                          VerticalScrollBarVisibility="Auto"
                          HorizontalScrollBarVisibility="Auto"
                          Margin="5"
-                         TextWrapping="Wrap" />
+                         TextWrapping="Wrap"
+                         TextChanged="RawDataTextBox_TextChanged" />
             </StackPanel>
         </Grid>
     </DockPanel>


### PR DESCRIPTION
## Summary
- disable DataGrid and show grey overlay when Raw Data panel visible
- allow editing Raw Data and save into the current node

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.csproj' -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422e1d0ea4832591bf34b4f2e1b918