### PR TITLE
Fix cancel edit behavior

### DIFF
--- a/PSSG Editor/MainWindow.xaml.cs
+++ b/PSSG Editor/MainWindow.xaml.cs
@@ -387,6 +387,9 @@ namespace PSSGEditor
         private void AttributesDataGrid_CellEditEnding(object sender, DataGridCellEditEndingEventArgs e)
         {
             if (currentNode == null) return;
+            // If the edit was cancelled (e.g. by pressing Esc), do not update the data
+            if (e.EditAction != DataGridEditAction.Commit)
+                return;
             var item = (AttributeItem)e.Row.Item;
             string attrName = item.Key;
 


### PR DESCRIPTION
## Summary
- ensure DataGrid cell edits aren't saved when cancelled

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.csproj' -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422ec768788325826876cf6afbd0fe