### PR TITLE
Fix attribute IDs when rewriting PSSG files

### DIFF
--- a/pssg.py
+++ b/pssg.py
@@ -214,11 +214,16 @@ class PSSGParser:
         return node
 
 class PSSGWriter:
-    def __init__(self, root):
+    def __init__(self, root, schema=None):
         self.root = root
-        self.schema = PSSGSchema()
-        # Восстанавливаем схему из уже изменённого дерева (присваиваем новые NodeID/AttrID)
-        self.schema.build_from_tree(root)
+        if schema is not None:
+            # Используем предоставленную схему (например, из исходного файла),
+            # чтобы сохранить исходные идентификаторы узлов и атрибутов
+            self.schema = schema
+        else:
+            # Если схема не передана, строим её заново по дереву
+            self.schema = PSSGSchema()
+            self.schema.build_from_tree(root)
 
     def _compute_sizes(self, node):
         """


### PR DESCRIPTION
## Summary
- allow `PSSGWriter` to reuse the schema from the source file

## Testing
- `python3 -m py_compile pssg.py pssg_editor.py`
- `python3 - <<'PY'
from pssg import PSSGParser, PSSGWriter
p = PSSGParser('land.pssg'); root = p.parse(); PSSGWriter(root, p.schema).save('land_new.pssg')
orig = PSSGParser('land.pssg'); orig.parse()
new = PSSGParser('land_new.pssg'); new.parse()
print(orig.schema.node_name_to_id == new.schema.node_name_to_id)
print(all(orig.schema.attr_name_to_id.get(n)==new.schema.attr_name_to_id.get(n) for n in orig.schema.attr_name_to_id))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68425132e2fc8325b7acb6257d0a32a2