### PR TITLE
Fix attribute schema regeneration

### DIFF
--- a/pssg.py
+++ b/pssg.py
@@ -216,8 +216,10 @@ class PSSGParser:
 class PSSGWriter:
     def __init__(self, root):
         self.root = root
+        # Всегда строим новую схему из текущего дерева.
+        # Это гарантирует, что в заголовке будут перечислены только те
+        # атрибуты и узлы, которые действительно присутствуют после редактирования.
         self.schema = PSSGSchema()
-        # Восстанавливаем схему из уже изменённого дерева (присваиваем новые NodeID/AttrID)
         self.schema.build_from_tree(root)
 
     def _compute_sizes(self, node):
@@ -298,10 +300,7 @@ class PSSGWriter:
 
         # Пишем каждый атрибут: AttrID, ValueSize, Value
         for attr_name, value in node.attributes.items():
-            if attr_name == 'id':
-                # Если пользователь вручную оставил «id», считаем, что этот идентификатор = 63
-                attr_id = 63
-            elif attr_name in self.schema.attr_name_to_id.get(node.name, {}):
+            if attr_name in self.schema.attr_name_to_id.get(node.name, {}):
                 # Если имя атрибута есть в локальной схеме этого node.name
                 attr_id = self.schema.attr_name_to_id[node.name][attr_name]
             elif attr_name in self.schema.global_attr_name_to_id:


### PR DESCRIPTION
## Summary
- always rebuild the PSSG schema when writing files so attribute IDs match the current data
- drop the hardcoded id attribute mapping so new files have consistent attribute IDs

## Testing
- `python3 -m py_compile pssg.py pssg_editor.py`
- `python3 - <<'PY'
from pssg import PSSGParser, PSSGWriter
p1 = PSSGParser('land.pssg'); root = p1.parse(); PSSGWriter(root).save('land_new.pssg');
p2 = PSSGParser('land_new.pssg'); p2.parse();
print('new id attr id', p2.schema.attr_name_to_id['ROOTNODE']['id'])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68425132e2fc8325b7acb6257d0a32a2