### PR TITLE
Enable file open via command line

### DIFF
--- a/PSSG Editor/App.xaml
+++ b/PSSG Editor/App.xaml
@@ -1,8 +1,7 @@
 ﻿<!-- App.xaml -->
-<Application x:Class="PSSG_Editor.App"
+<Application x:Class="PSSGEditor.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             StartupUri="MainWindow.xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Application.Resources>
         <!-- Здесь можно определить глобальные стили, если надо -->
     </Application.Resources>

--- a/PSSG Editor/App.xaml.cs
+++ b/PSSG Editor/App.xaml.cs
@@ -5,6 +5,23 @@ namespace PSSGEditor
 {
     public partial class App : Application
     {
-        // Никакой дополнительной логики не требуется — всё в MainWindow
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            base.OnStartup(e);
+
+            var mainWindow = new MainWindow();
+            MainWindow = mainWindow;
+
+            if (e.Args.Length > 0)
+            {
+                string file = e.Args[0];
+                if (System.IO.File.Exists(file))
+                {
+                    mainWindow.LoadFile(file);
+                }
+            }
+
+            mainWindow.Show();
+        }
     }
 }

--- a/PSSG Editor/MainWindow.xaml.cs
+++ b/PSSG Editor/MainWindow.xaml.cs
@@ -51,9 +51,14 @@ namespace PSSGEditor
             };
             if (ofd.ShowDialog() != true) return;
 
+            LoadFile(ofd.FileName);
+        }
+
+        public void LoadFile(string fileName)
+        {
             try
             {
-                var parser = new PSSGParser(ofd.FileName);
+                var parser = new PSSGParser(fileName);
                 rootNode = parser.Parse();
 
                 var stats = CollectStats(rootNode);


### PR DESCRIPTION
## Summary
- allow launching PSSG Editor with a file path
- expose `LoadFile` in `MainWindow`
- update project XAML to use custom startup logic

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.csproj' -v q` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68429411cea48325b994c21dff4cfcc9