### PR TITLE
Improve parsing performance

### DIFF
--- a/PSSG Editor/MainWindow.xaml.cs
+++ b/PSSG Editor/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Buffers.Binary;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -376,29 +377,18 @@ namespace PSSGEditor
 
         private uint ReadUInt32FromBytes(byte[] arr, int offset)
         {
-            var temp = new byte[4];
-            Array.Copy(arr, offset, temp, 0, 4);
-            if (BitConverter.IsLittleEndian)
-                Array.Reverse(temp);
-            return BitConverter.ToUInt32(temp, 0);
+            return BinaryPrimitives.ReadUInt32BigEndian(arr.AsSpan(offset));
         }
 
         private ushort ReadUInt16FromBytes(byte[] arr, int offset)
         {
-            var temp = new byte[2];
-            Array.Copy(arr, offset, temp, 0, 2);
-            if (BitConverter.IsLittleEndian)
-                Array.Reverse(temp);
-            return BitConverter.ToUInt16(temp, 0);
+            return BinaryPrimitives.ReadUInt16BigEndian(arr.AsSpan(offset));
         }
 
         private float ReadFloatFromBytes(byte[] arr, int offset)
         {
-            var temp = new byte[4];
-            Array.Copy(arr, offset, temp, 0, 4);
-            if (BitConverter.IsLittleEndian)
-                Array.Reverse(temp);
-            return BitConverter.ToSingle(temp, 0);
+            uint intVal = BinaryPrimitives.ReadUInt32BigEndian(arr.AsSpan(offset));
+            return BitConverter.Int32BitsToSingle((int)intVal);
         }
 
         private byte[] ToBigEndian(ushort value)


### PR DESCRIPTION
## Summary
- reduce memory allocations by using `BinaryPrimitives` when reading big-endian integers
- update conversions in the editor for faster attribute handling

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.csproj' -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68429f844e5083259a4111ebaae98428