### PR TITLE
Improve tree view responsiveness

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -1,6 +1,7 @@
 ﻿<Window x:Class="PSSGEditor.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:PSSGEditor"
         Title="PromixFlame PSSG Editor" Height="600" Width="900">
     <DockPanel>
         <!-- Menu с нижним разделителем -->
@@ -38,9 +39,18 @@
                       x:Name="PssgTreeView"
                       SelectedItemChanged="PssgTreeView_SelectedItemChanged"
                       Background="White"
+                      VirtualizingStackPanel.IsVirtualizing="True"
+                      VirtualizingStackPanel.VirtualizationMode="Recycling"
+                      ScrollViewer.CanContentScroll="True"
                       BorderThickness="0"
                       BorderBrush="Transparent"
-                      Padding="2" />
+                      Padding="2">
+                <TreeView.Resources>
+                    <HierarchicalDataTemplate DataType="{x:Type local:PSSGNode}" ItemsSource="{Binding Children}">
+                        <TextBlock Text="{Binding Name}" />
+                    </HierarchicalDataTemplate>
+                </TreeView.Resources>
+            </TreeView>
 
             <!-- Вертикальный сплиттер -->
             <GridSplitter Grid.Column="1"


### PR DESCRIPTION
## Summary
- bind `TreeView` directly to `PSSGNode` objects
- use `HierarchicalDataTemplate` so nodes generate lazily
- remove old incremental loading logic

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.csproj' -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68429f844e5083259a4111ebaae98428