### PR TITLE
Add build notes for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# F1 2012 Track Editor
+
+This repository contains a WPF editor for manipulating PSSG files used in Codemasters games.
+
+## Building
+
+The project is a Windows-only WPF application. The csproj sets `RuntimeIdentifier` to `win-x64`, so publishing is intended for 64‑bit Windows.
+
+To build a release build for distribution you can use the provided publish profile:
+
+```bash
+cd "PSSG Editor"
+dotnet publish -p:PublishProfile=Properties/PublishProfiles/FolderProfile.pubxml
+```
+
+This generates binaries under `bin/Release/net8.0-windows/publish/win-x64/`.


### PR DESCRIPTION
## Summary
- add a simple README
- mention `RuntimeIdentifier` (win-x64)
- suggest using the included publish profile

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.sln' -c Release` *(fails: WindowsDesktop SDK missing)*
- `dotnet publish -p:PublishProfile=Properties/PublishProfiles/FolderProfile.pubxml` *(fails: WindowsDesktop SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_68438117646c83259cae1cce67f4f9e0