### PR TITLE
Add gitattributes for binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.pssg binary
+*.grs binary
+*.ico binary


### PR DESCRIPTION
## Summary
- prevent diffing for `.pssg`, `.grs`, and `.ico` files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68438116d7748325a94bc03f376a8cf1