### PR TITLE
Add unit test for byte-perfect PSSG roundtrip

### DIFF
--- a/tests/PSSGEditor.Tests/BytePerfectTests.cs
+++ b/tests/PSSGEditor.Tests/BytePerfectTests.cs
@@ -1,0 +1,35 @@
+using System.IO;
+using Xunit;
+using PSSGEditor;
+
+namespace PSSGEditor.Tests;
+
+public class BytePerfectTests
+{
+    [Fact]
+    public void Roundtrip_Produces_Identical_File()
+    {
+        var baseDir = AppContext.BaseDirectory;
+        var samplePath = Path.GetFullPath(Path.Combine(baseDir, "..", "..", "..", "..", "..", "catalunya", "land.pssg"));
+        var originalBytes = File.ReadAllBytes(samplePath);
+
+        var parser = new PSSGParser(samplePath);
+        var root = parser.Parse();
+        var schema = parser.Schema;
+
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            var writer = new PSSGWriter(root, schema);
+            writer.Save(tempFile);
+
+            var newBytes = File.ReadAllBytes(tempFile);
+            Assert.Equal(originalBytes, newBytes);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+}

--- a/tests/PSSGEditor.Tests/GlobalUsings.cs
+++ b/tests/PSSGEditor.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/PSSGEditor.Tests/PSSGEditor.Tests.csproj
+++ b/tests/PSSGEditor.Tests/PSSGEditor.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../../PSSG Editor/PSSGFormat.cs" Link="PSSGFormat.cs" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- expose parser schema and preserve numeric IDs when parsing
- allow writer to reuse existing schema and original IDs
- add xUnit test project under `tests/`
- implement `BytePerfectTests` to verify round-trip output matches source

## Testing
- `dotnet test tests/PSSGEditor.Tests/PSSGEditor.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6843811570688325824fadf97cbca01d