### PR TITLE
Optimize editor loading and UI virtualization

### DIFF
--- a/PSSG Editor/App.xaml.cs
+++ b/PSSG Editor/App.xaml.cs
@@ -17,7 +17,7 @@ namespace PSSGEditor
                 string file = e.Args[0];
                 if (System.IO.File.Exists(file))
                 {
-                    mainWindow.LoadFile(file);
+                    mainWindow.LoadFileAsync(file).GetAwaiter().GetResult();
                 }
             }
 

--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -66,6 +66,8 @@
                       AutoGenerateColumns="False"
                       CanUserAddRows="False"
                       IsReadOnly="False"
+                      EnableRowVirtualization="True"
+                      EnableColumnVirtualization="True"
                       HeadersVisibility="Column"
                       RowHeaderWidth="0"
                       SelectionUnit="Cell"


### PR DESCRIPTION
## Summary
- lazily load node data on demand
- stream file data from `FileStream` instead of reading all bytes at once
- expose asynchronous file loading so UI stays responsive
- enable virtualization in the attribute grid
- reduce allocations when converting display strings

## Testing
- `dotnet build "PSSG Editor/PSSG Editor.csproj" -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843838bd6488325a94583631a53d378