### PR TITLE
Ensure PSSG Editor process exits

### DIFF
--- a/PSSG Editor/App.xaml
+++ b/PSSG Editor/App.xaml
@@ -1,7 +1,8 @@
 ﻿<!-- App.xaml -->
 <Application x:Class="PSSGEditor.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             ShutdownMode="OnMainWindowClose">
     <Application.Resources>
         <!-- Здесь можно определить глобальные стили, если надо -->
     </Application.Resources>


### PR DESCRIPTION
## Summary
- set `ShutdownMode` so the WPF app ends when the main window closes

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.sln' -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d733f3908325b08744caf037c9cb