### PR TITLE
Adjust Raw Data panel layout

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -39,7 +39,7 @@
             </Grid.RowDefinitions>
 
             <!-- Левый TreeView без обводки -->
-            <TreeView Grid.Column="0"
+            <TreeView Grid.Column="0" Grid.RowSpan="2"
                       x:Name="PssgTreeView"
                       SelectedItemChanged="PssgTreeView_SelectedItemChanged"
                       Background="White"
@@ -57,7 +57,7 @@
             </TreeView>
 
             <!-- Вертикальный сплиттер -->
-            <GridSplitter Grid.Column="1"
+            <GridSplitter Grid.Column="1" Grid.RowSpan="2"
                           HorizontalAlignment="Stretch"
                           VerticalAlignment="Stretch"
                           Width="5"


### PR DESCRIPTION
## Summary
- keep left `TreeView` and splitter spanning both rows
- show Raw Data panel only under the DataGrid

## Testing
- `dotnet build "PSSG Editor/PSSG Editor.csproj" -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_6843db64c3ac8325ab34aae0b9f174d7