### PR TITLE
Fix startup hang when launching via file association

### DIFF
--- a/PSSG Editor/App.xaml.cs
+++ b/PSSG Editor/App.xaml.cs
@@ -5,7 +5,7 @@ namespace PSSGEditor
 {
     public partial class App : Application
     {
-        protected override void OnStartup(StartupEventArgs e)
+        protected override async void OnStartup(StartupEventArgs e)
         {
             base.OnStartup(e);
 
@@ -17,7 +17,7 @@ namespace PSSGEditor
                 string file = e.Args[0];
                 if (System.IO.File.Exists(file))
                 {
-                    mainWindow.LoadFileAsync(file).GetAwaiter().GetResult();
+                    await mainWindow.LoadFileAsync(file);
                 }
             }
 


### PR DESCRIPTION
## Summary
- avoid a deadlock in `OnStartup` when the app receives a file to open

## Testing
- `dotnet build "PSSG Editor/PSSG Editor.csproj" -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6843f2ecdfd88325bfd19a4f1cee7f01