### PR TITLE
Adjust Raw Data panel layout

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -34,12 +34,12 @@
                 <ColumnDefinition Width="5*" />
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
-                <RowDefinition Height="*" />
-                <RowDefinition Height="Auto" />
+                <RowDefinition x:Name="AttributesRow" Height="*" />
+                <RowDefinition x:Name="RawDataRow" Height="Auto" />
             </Grid.RowDefinitions>
 
             <!-- Левый TreeView без обводки -->
-            <TreeView Grid.Column="0"
+            <TreeView Grid.Column="0" Grid.RowSpan="2"
                       x:Name="PssgTreeView"
                       SelectedItemChanged="PssgTreeView_SelectedItemChanged"
                       Background="White"
@@ -57,7 +57,7 @@
             </TreeView>
 
             <!-- Вертикальный сплиттер -->
-            <GridSplitter Grid.Column="1"
+            <GridSplitter Grid.Column="1" Grid.RowSpan="2"
                           HorizontalAlignment="Stretch"
                           VerticalAlignment="Stretch"
                           Width="5"

--- a/PSSG Editor/MainWindow.xaml.cs
+++ b/PSSG Editor/MainWindow.xaml.cs
@@ -163,6 +163,9 @@ namespace PSSGEditor
             AttributesDataGrid.IsEnabled = true;
             rawDataOriginalLength = 0;
             isLoadingRawData = false;
+            AttributesDataGrid.Visibility = Visibility.Collapsed;
+            AttributesRow.Height = new GridLength(0);
+            RawDataRow.Height = new GridLength(0);
 
             var listForGrid = new List<AttributeItem>();
 
@@ -196,8 +199,30 @@ namespace PSSGEditor
                 isLoadingRawData = false;
             }
 
-            // Даже если список пуст, DataGrid остаётся видим
             AttributesDataGrid.ItemsSource = listForGrid;
+
+            // Настраиваем видимость и размеры строк
+            if (listForGrid.Count > 0)
+            {
+                AttributesDataGrid.Visibility = Visibility.Visible;
+                AttributesRow.Height = new GridLength(1, GridUnitType.Star);
+            }
+            else
+            {
+                AttributesDataGrid.Visibility = Visibility.Collapsed;
+                AttributesRow.Height = new GridLength(0);
+            }
+
+            if (RawDataPanel.Visibility == Visibility.Visible)
+            {
+                RawDataRow.Height = AttributesDataGrid.Visibility == Visibility.Visible
+                    ? GridLength.Auto
+                    : new GridLength(1, GridUnitType.Star);
+            }
+            else
+            {
+                RawDataRow.Height = new GridLength(0);
+            }
 
             // Восстанавливаем сортировку, если была
             if (!string.IsNullOrEmpty(savedSortMember) && savedSortDirection.HasValue)
@@ -217,8 +242,6 @@ namespace PSSGEditor
                 }
             }
 
-            // DataGrid всегда видим
-            AttributesDataGrid.Visibility = Visibility.Visible;
         }
 
         #endregion


### PR DESCRIPTION
## Summary
- fine-tune grid layout with named row definitions
- toggle DataGrid and Raw Data visibility depending on node contents
- resize rows so whichever panel is visible fills the space

## Testing
- `dotnet build "PSSG Editor/PSSG Editor.csproj" -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_6843db64c3ac8325ab34aae0b9f174d7