### PR TITLE
Update raw data display handling

### DIFF
--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -35,7 +35,8 @@
             </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <RowDefinition x:Name="AttributesRow" Height="*" />
-                <RowDefinition x:Name="RawDataRow" Height="Auto" />
+                <!-- RawDataRow will expand to fill remaining space when visible -->
+                <RowDefinition x:Name="RawDataRow" Height="*" />
             </Grid.RowDefinitions>
 
             <!-- Левый TreeView без обводки -->


### PR DESCRIPTION
## Summary
- allow Raw Data row to fill available space
- format raw byte blocks as uppercase hex except for transforms/bounding boxes
- support spaced hex strings when editing Raw Data

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.sln' -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68440e3d0a5483258ee314e254c54f9e