### PR TITLE
Add dark theme option

### DIFF
--- a/PSSG Editor/App.xaml
+++ b/PSSG Editor/App.xaml
@@ -4,6 +4,10 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              ShutdownMode="OnMainWindowClose">
     <Application.Resources>
-        <!-- Здесь можно определить глобальные стили, если надо -->
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Themes/LightTheme.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -2,23 +2,26 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:PSSGEditor"
-        Title="PromixFlame PSSG Editor" Height="600" Width="900">
+        Title="PromixFlame PSSG Editor" Height="600" Width="900" Background="{DynamicResource WindowBackgroundBrush}" Foreground="{DynamicResource ControlForegroundBrush}">
     <DockPanel>
         <!-- Menu с нижним разделителем -->
-        <Border DockPanel.Dock="Top" BorderBrush="Black" BorderThickness="0,0,0,1">
-            <Menu>
+        <Border DockPanel.Dock="Top" BorderBrush="{DynamicResource BorderBrushColor}" BorderThickness="0,0,0,1">
+            <Menu Background="{DynamicResource ControlBackgroundBrush}" Foreground="{DynamicResource ControlForegroundBrush}">
                 <MenuItem Header="_File">
                     <MenuItem x:Name="OpenMenuItem" Header="_Open" Click="OpenMenuItem_Click"/>
                     <MenuItem x:Name="SaveAsMenuItem" Header="Save _As" Click="SaveAsMenuItem_Click"/>
                     <Separator/>
                     <MenuItem Header="E_xit" Click="ExitMenuItem_Click"/>
                 </MenuItem>
+                <MenuItem Header="_View">
+                    <MenuItem x:Name="DarkThemeMenuItem" Header="_Dark Theme" IsCheckable="True" Click="DarkThemeMenuItem_Click"/>
+                </MenuItem>
             </Menu>
         </Border>
 
         <!-- Строка статуса с верхним разделителем -->
-        <Border DockPanel.Dock="Bottom" BorderBrush="Black" BorderThickness="0,1,0,0">
-            <StatusBar>
+        <Border DockPanel.Dock="Bottom" BorderBrush="{DynamicResource BorderBrushColor}" BorderThickness="0,1,0,0">
+            <StatusBar Background="{DynamicResource ControlBackgroundBrush}" Foreground="{DynamicResource ControlForegroundBrush}">
                 <StatusBarItem x:Name="StatusBar">
                     <TextBlock x:Name="StatusText" Text="Ready" />
                 </StatusBarItem>
@@ -27,7 +30,7 @@
 
         <!-- Основная область: две панели без каких-либо внешних рамок -->
             <Grid x:Name="MainGrid"
-                  Background="Gray">
+                  Background="{DynamicResource WindowBackgroundBrush}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="2*" />
                 <ColumnDefinition Width="5" />
@@ -43,7 +46,7 @@
             <TreeView Grid.Column="0" Grid.RowSpan="2"
                       x:Name="PssgTreeView"
                       SelectedItemChanged="PssgTreeView_SelectedItemChanged"
-                      Background="White"
+                      Background="{DynamicResource ControlBackgroundBrush}" Foreground="{DynamicResource ControlForegroundBrush}"
                       VirtualizingStackPanel.IsVirtualizing="True"
                       VirtualizingStackPanel.VirtualizationMode="Recycling"
                       ScrollViewer.CanContentScroll="True"
@@ -62,7 +65,7 @@
                           HorizontalAlignment="Stretch"
                           VerticalAlignment="Stretch"
                           Width="5"
-                          Background="LightGray"
+                          Background="{DynamicResource BorderBrushColor}"
                           ShowsPreview="True" />
 
             <!-- Правая панель: DataGrid без обводки -->
@@ -80,7 +83,7 @@
                       PreviewMouseLeftButtonDown="AttributesDataGrid_PreviewMouseLeftButtonDown"
                       PreviewKeyDown="AttributesDataGrid_PreviewKeyDown"
                       Sorting="AttributesDataGrid_Sorting"
-                      Background="Gray"
+                      Background="{DynamicResource ControlBackgroundBrush}" Foreground="{DynamicResource ControlForegroundBrush}"
                       BorderThickness="0"
                       BorderBrush="Transparent"
                       Visibility="Collapsed">
@@ -93,7 +96,7 @@
                                         Width="Auto">
                         <DataGridTextColumn.CellStyle>
                             <Style TargetType="DataGridCell">
-                                <Setter Property="Background" Value="#EEEEEE" />
+                                <Setter Property="Background" Value="{DynamicResource SecondaryBackgroundBrush}" />
                                 <Style.Triggers>
                                     <Trigger Property="IsSelected" Value="True">
                                         <Setter Property="Background"
@@ -123,7 +126,7 @@
                   Grid.Row="1"
                       x:Name="RawDataPanel"
                       Visibility="Collapsed"
-                      Background="#ececec"
+                      Background="{DynamicResource SecondaryBackgroundBrush}"
                       Panel.ZIndex="1">
                    <Grid.RowDefinitions>
                    <!-- Заголовок «Raw Data» (обязательно Auto, чтобы он не «тянулся») -->
@@ -145,8 +148,8 @@
                            HorizontalScrollBarVisibility="Auto"
                            TextWrapping="Wrap"
                            Margin="5,0,5,5"
-                           Background="White"
-                           BorderBrush="DarkGray"
+                           Background="{DynamicResource ControlBackgroundBrush}" Foreground="{DynamicResource ControlForegroundBrush}"
+                           BorderBrush="{DynamicResource BorderBrushColor}"
                            BorderThickness="1">
                 </TextBox>
             </Grid>

--- a/PSSG Editor/MainWindow.xaml.cs
+++ b/PSSG Editor/MainWindow.xaml.cs
@@ -110,6 +110,22 @@ namespace PSSGEditor
             this.Close();
         }
 
+        private void DarkThemeMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            if (DarkThemeMenuItem.IsChecked)
+            {
+                Application.Current.Resources.MergedDictionaries.Clear();
+                Application.Current.Resources.MergedDictionaries.Add(
+                    new ResourceDictionary { Source = new Uri("Themes/DarkTheme.xaml", UriKind.Relative) });
+            }
+            else
+            {
+                Application.Current.Resources.MergedDictionaries.Clear();
+                Application.Current.Resources.MergedDictionaries.Add(
+                    new ResourceDictionary { Source = new Uri("Themes/LightTheme.xaml", UriKind.Relative) });
+            }
+        }
+
         #endregion
 
         #region TreeView & Display Logic
@@ -158,7 +174,8 @@ namespace PSSGEditor
             isLoadingRawData = true;
             RawDataTextBox.Text = string.Empty;
             RawDataTextBox.IsReadOnly = false;
-            RawDataTextBox.Background = Brushes.White;
+            RawDataTextBox.Background = (Brush)FindResource("ControlBackgroundBrush");
+            RawDataTextBox.Foreground = (Brush)FindResource("ControlForegroundBrush");
             RawDataPanel.Visibility = Visibility.Collapsed;
             AttributesDataGrid.IsEnabled = true;
             rawDataOriginalLength = 0;

--- a/PSSG Editor/Themes/DarkTheme.xaml
+++ b/PSSG Editor/Themes/DarkTheme.xaml
@@ -1,0 +1,8 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <SolidColorBrush x:Key="WindowBackgroundBrush" Color="#000000" />
+    <SolidColorBrush x:Key="ControlBackgroundBrush" Color="#111111" />
+    <SolidColorBrush x:Key="ControlForegroundBrush" Color="#e6cf95" />
+    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#1b1b1b" />
+    <SolidColorBrush x:Key="BorderBrushColor" Color="#e6cf95" />
+</ResourceDictionary>

--- a/PSSG Editor/Themes/LightTheme.xaml
+++ b/PSSG Editor/Themes/LightTheme.xaml
@@ -1,0 +1,8 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <SolidColorBrush x:Key="WindowBackgroundBrush" Color="Gray" />
+    <SolidColorBrush x:Key="ControlBackgroundBrush" Color="White" />
+    <SolidColorBrush x:Key="ControlForegroundBrush" Color="Black" />
+    <SolidColorBrush x:Key="SecondaryBackgroundBrush" Color="#ececec" />
+    <SolidColorBrush x:Key="BorderBrushColor" Color="Black" />
+</ResourceDictionary>


### PR DESCRIPTION
## Summary
- add simple LightTheme and DarkTheme resource dictionaries
- load LightTheme by default
- add View -> Dark Theme menu option
- apply colors via dynamic resources so theme changes update the UI

## Testing
- `dotnet build "PSSG Editor/PSSG Editor.csproj" -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844106d21308325b2ab7ae9fa3f2380