### PR TITLE
Add DDS texture import/export features

### DIFF
--- a/PSSG Editor/MainWindow.TextureHandlers.cs
+++ b/PSSG Editor/MainWindow.TextureHandlers.cs
@@ -6,6 +6,8 @@ using System.Buffers.Binary;
 using System.IO;
 using System.Windows.Media.Imaging;
 using System.Windows.Controls;
+using System.Windows;
+using System.Windows.Forms;
 
 namespace PSSGEditor
 {
@@ -171,6 +173,190 @@ namespace PSSGEditor
             Buffer.BlockCopy(header, 0, result, 0, header.Length);
             Buffer.BlockCopy(data, 0, result, header.Length, data.Length);
             return result;
+        }
+
+        private static byte[] EncodeString(string s)
+        {
+            var bytes = Encoding.UTF8.GetBytes(s);
+            var arr = new byte[bytes.Length + 4];
+            BinaryPrimitives.WriteUInt32BigEndian(arr.AsSpan(), (uint)bytes.Length);
+            Buffer.BlockCopy(bytes, 0, arr, 4, bytes.Length);
+            return arr;
+        }
+
+        private static (uint width, uint height, uint mipMaps, string format, byte[] data)? ParseDds(string path)
+        {
+            var bytes = File.ReadAllBytes(path);
+            if (bytes.Length < 128 || bytes[0] != 'D' || bytes[1] != 'D' || bytes[2] != 'S' || bytes[3] != ' ')
+                return null;
+            uint height = BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(12));
+            uint width = BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(16));
+            uint mipMaps = BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(28));
+            if (mipMaps == 0) mipMaps = 1;
+            uint pfFlags = BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(80));
+            uint fourCC = BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(84));
+            string format = "argb";
+            if ((pfFlags & 0x4) != 0)
+            {
+                if (fourCC == 0x31545844) format = "dxt1";
+                else if (fourCC == 0x33545844) format = "dxt3";
+                else if (fourCC == 0x35545844) format = "dxt5";
+            }
+            var data = bytes.AsSpan(128).ToArray();
+            return (width, height, mipMaps, format, data);
+        }
+
+        private static PSSGNode? FindParent(PSSGNode root, PSSGNode child)
+        {
+            var stack = new Stack<PSSGNode>();
+            stack.Push(root);
+            while (stack.Count > 0)
+            {
+                var n = stack.Pop();
+                for (int i = 0; i < n.Children.Count; i++)
+                {
+                    if (n.Children[i] == child)
+                        return n;
+                    stack.Push(n.Children[i]);
+                }
+            }
+            return null;
+        }
+
+        private PSSGNode? FindTextureLibrary()
+        {
+            if (rootNode == null) return null;
+            var stack = new Stack<PSSGNode>();
+            stack.Push(rootNode);
+            while (stack.Count > 0)
+            {
+                var n = stack.Pop();
+                if (n.Name == "LIBRARY" && n.Attributes.TryGetValue("type", out var t) && DecodeString(t) == "YYY")
+                    return n;
+                foreach (var c in n.Children) stack.Push(c);
+            }
+            return null;
+        }
+
+        private void DeleteTextureMenuItem_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            if (TexturesListBox.SelectedItem is not TextureEntry entry || rootNode == null)
+                return;
+            var parent = FindParent(rootNode, entry.Node);
+            parent?.Children.Remove(entry.Node);
+            textureEntries.Remove(entry);
+            PopulateTextureList();
+            TexturePreviewImage.Source = null;
+        }
+
+        private void ImportTextureMenuItem_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            if (TexturesListBox.SelectedItem is not TextureEntry entry) return;
+            var ofd = new Microsoft.Win32.OpenFileDialog { Filter = "DDS files (*.dds)|*.dds" };
+            if (ofd.ShowDialog() != true) return;
+            ImportIntoNode(entry.Node, ofd.FileName);
+            PopulateTextureList();
+            ShowTexture(entry.Node);
+        }
+
+        private void ExportTextureMenuItem_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            if (TexturesListBox.SelectedItem is not TextureEntry entry) return;
+            var dds = BuildDds(entry.Node);
+            if (dds == null) return;
+            var sfd = new Microsoft.Win32.SaveFileDialog { Filter = "DDS files (*.dds)|*.dds", FileName = entry.Name + ".dds" };
+            if (sfd.ShowDialog() != true) return;
+            File.WriteAllBytes(sfd.FileName, dds);
+        }
+
+        private void NewTextureMenuItem_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            var ofd = new Microsoft.Win32.OpenFileDialog { Filter = "DDS files (*.dds)|*.dds" };
+            if (ofd.ShowDialog() != true) return;
+            AddNewTexture(ofd.FileName);
+        }
+
+        private void ImportFolderMenuItem_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            var dlg = new System.Windows.Forms.FolderBrowserDialog();
+            if (dlg.ShowDialog() != System.Windows.Forms.DialogResult.OK) return;
+            foreach (var file in Directory.EnumerateFiles(dlg.SelectedPath, "*.dds"))
+            {
+                string id = Path.GetFileNameWithoutExtension(file);
+                var existing = textureEntries.FirstOrDefault(t => t.Name.Equals(id, StringComparison.OrdinalIgnoreCase));
+                if (existing != null) ImportIntoNode(existing.Node, file);
+                else AddNewTexture(file);
+            }
+            PopulateTextureList();
+        }
+
+        private void ExportAllTexturesMenuItem_Click(object sender, System.Windows.RoutedEventArgs e)
+        {
+            var dlg = new System.Windows.Forms.FolderBrowserDialog();
+            if (dlg.ShowDialog() != System.Windows.Forms.DialogResult.OK) return;
+            foreach (var entry in textureEntries)
+            {
+                var dds = BuildDds(entry.Node);
+                if (dds != null)
+                {
+                    var path = Path.Combine(dlg.SelectedPath, entry.Name + ".dds");
+                    File.WriteAllBytes(path, dds);
+                }
+            }
+        }
+
+        private void ImportIntoNode(PSSGNode texNode, string filePath)
+        {
+            var info = ParseDds(filePath);
+            if (info == null) return;
+            texNode.Attributes["width"] = ToBigEndian(info.Value.width);
+            texNode.Attributes["height"] = ToBigEndian(info.Value.height);
+            texNode.Attributes["texelFormat"] = EncodeString(info.Value.format);
+            texNode.Attributes["numberMipMapLevels"] = ToBigEndian(info.Value.mipMaps);
+
+            var block = texNode.Children.FirstOrDefault(c => c.Name == "TEXTUREIMAGEBLOCK");
+            if (block == null)
+            {
+                block = new PSSGNode("TEXTUREIMAGEBLOCK");
+                texNode.Children.Add(block);
+            }
+            block.Attributes["typename"] = EncodeString("Raw");
+            block.Attributes["size"] = ToBigEndian((uint)info.Value.data.Length);
+
+            var dataNode = block.Children.FirstOrDefault(c => c.Name == "TEXTUREIMAGEBLOCKDATA");
+            if (dataNode == null)
+            {
+                dataNode = new PSSGNode("TEXTUREIMAGEBLOCKDATA");
+                block.Children.Add(dataNode);
+            }
+            dataNode.Data = info.Value.data;
+        }
+
+        private void AddNewTexture(string filePath)
+        {
+            var info = ParseDds(filePath);
+            if (info == null || rootNode == null) return;
+            string id = Path.GetFileNameWithoutExtension(filePath);
+            var tex = new PSSGNode("TEXTURE");
+            tex.Attributes["id"] = EncodeString(id);
+            tex.Attributes["width"] = ToBigEndian(info.Value.width);
+            tex.Attributes["height"] = ToBigEndian(info.Value.height);
+            tex.Attributes["texelFormat"] = EncodeString(info.Value.format);
+            tex.Attributes["numberMipMapLevels"] = ToBigEndian(info.Value.mipMaps);
+
+            var block = new PSSGNode("TEXTUREIMAGEBLOCK");
+            block.Attributes["typename"] = EncodeString("Raw");
+            block.Attributes["size"] = ToBigEndian((uint)info.Value.data.Length);
+            var dataNode = new PSSGNode("TEXTUREIMAGEBLOCKDATA");
+            dataNode.Data = info.Value.data;
+            block.Children.Add(dataNode);
+            tex.Children.Add(block);
+
+            var lib = FindTextureLibrary() ?? rootNode;
+            lib.Children.Add(tex);
+
+            textureEntries.Add(new TextureEntry { Name = id, Node = tex });
+            PopulateTextureList();
         }
     }
 }

--- a/PSSG Editor/MainWindow.xaml
+++ b/PSSG Editor/MainWindow.xaml
@@ -13,6 +13,10 @@
                     <Separator/>
                     <MenuItem Header="E_xit" Click="ExitMenuItem_Click"/>
                 </MenuItem>
+                <MenuItem Header="Textures">
+                    <MenuItem Header="Import Folder" Click="ImportFolderMenuItem_Click"/>
+                    <MenuItem Header="Export All Textures" Click="ExportAllTexturesMenuItem_Click"/>
+                </MenuItem>
             </Menu>
         </Border>
 
@@ -168,7 +172,16 @@
                     <ListBox x:Name="TexturesListBox"
                              Grid.Column="0"
                              Background="White"
-                             SelectionChanged="TexturesListBox_SelectionChanged" />
+                             SelectionChanged="TexturesListBox_SelectionChanged">
+                        <ListBox.ContextMenu>
+                            <ContextMenu>
+                                <MenuItem Header="Delete" Click="DeleteTextureMenuItem_Click"/>
+                                <MenuItem Header="Import Texture" Click="ImportTextureMenuItem_Click"/>
+                                <MenuItem Header="Export Texture" Click="ExportTextureMenuItem_Click"/>
+                                <MenuItem Header="New Texture" Click="NewTextureMenuItem_Click"/>
+                            </ContextMenu>
+                        </ListBox.ContextMenu>
+                    </ListBox>
 
                     <GridSplitter Grid.Column="1"
                                   HorizontalAlignment="Stretch"

--- a/PSSG Editor/PSSG Editor.csproj
+++ b/PSSG Editor/PSSG Editor.csproj
@@ -6,7 +6,8 @@
 
 		<!-- Целевая платформа: .NET 8 WPF -->
 		<TargetFramework>net8.0-windows</TargetFramework>
-		<UseWPF>true</UseWPF>
+                <UseWPF>true</UseWPF>
+                <UseWindowsForms>true</UseWindowsForms>
 
 		<!-- Publish as single-file without embedding full runtime -->
 		<PublishSingleFile>true</PublishSingleFile>


### PR DESCRIPTION
## Summary
- add Textures menu with bulk import/export
- support context menu on texture list (delete, import, export, new)
- implement DDS parser and texture node helpers
- enable Windows Forms for folder dialogs

## Testing
- `dotnet build "PSSG Editor/PSSG Editor.csproj" -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_684545e3ff2c8325aba27344d38fb1b9