### PR TITLE
Fix ItemsControl mismatch on texture list refresh

### DIFF
--- a/PSSG Editor/MainWindow.TextureHandlers.cs
+++ b/PSSG Editor/MainWindow.TextureHandlers.cs
@@ -23,8 +23,8 @@ namespace PSSGEditor
 
         private void PopulateTextureList()
         {
-            textureEntries.Clear();
             TexturesListBox.ItemsSource = null;
+            textureEntries.Clear();
             if (rootNode == null) return;
 
             var stack = new Stack<PSSGNode>();


### PR DESCRIPTION
## Summary
- fix ItemsControl error by clearing the ListBox `ItemsSource` before clearing the backing list

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.csproj' -clp:ErrorsOnly` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68458d6530648325b73533090f96f970