### PR TITLE
Fix ItemsControl mismatch on texture add/remove

### DIFF
--- a/PSSG Editor/MainWindow.TextureHandlers.cs
+++ b/PSSG Editor/MainWindow.TextureHandlers.cs
@@ -23,8 +23,8 @@ namespace PSSGEditor
 
         private void PopulateTextureList()
         {
-            textureEntries.Clear();
             TexturesListBox.ItemsSource = null;
+            textureEntries.Clear();
             if (rootNode == null) return;
 
             var stack = new Stack<PSSGNode>();
@@ -242,6 +242,7 @@ namespace PSSGEditor
         {
             if (TexturesListBox.SelectedItem is not TextureEntry entry || rootNode == null)
                 return;
+            TexturesListBox.ItemsSource = null;
             var parent = FindParent(rootNode, entry.Node);
             parent?.Children.Remove(entry.Node);
             textureEntries.Remove(entry);
@@ -337,6 +338,7 @@ namespace PSSGEditor
             var info = ParseDds(filePath);
             if (info == null || rootNode == null) return;
             string id = Path.GetFileNameWithoutExtension(filePath);
+            TexturesListBox.ItemsSource = null;
             var tex = new PSSGNode("TEXTURE");
             tex.Attributes["id"] = EncodeString(id);
             tex.Attributes["width"] = ToBigEndian(info.Value.width);


### PR DESCRIPTION
## Summary
- unbind `TexturesListBox.ItemsSource` before modifying the backing list during add/remove

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.csproj' -clp:ErrorsOnly` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68458d6530648325b73533090f96f970