### PR TITLE
Fix tree view refresh when editing textures

### DIFF
--- a/PSSG Editor/MainWindow.TextureHandlers.cs
+++ b/PSSG Editor/MainWindow.TextureHandlers.cs
@@ -23,8 +23,8 @@ namespace PSSGEditor
 
         private void PopulateTextureList()
         {
-            textureEntries.Clear();
             TexturesListBox.ItemsSource = null;
+            textureEntries.Clear();
             if (rootNode == null) return;
 
             var stack = new Stack<PSSGNode>();
@@ -242,9 +242,12 @@ namespace PSSGEditor
         {
             if (TexturesListBox.SelectedItem is not TextureEntry entry || rootNode == null)
                 return;
+            PssgTreeView.ItemsSource = null;
+            TexturesListBox.ItemsSource = null;
             var parent = FindParent(rootNode, entry.Node);
             parent?.Children.Remove(entry.Node);
             textureEntries.Remove(entry);
+            PopulateTreeView();
             PopulateTextureList();
             TexturePreviewImage.Source = null;
         }
@@ -337,6 +340,8 @@ namespace PSSGEditor
             var info = ParseDds(filePath);
             if (info == null || rootNode == null) return;
             string id = Path.GetFileNameWithoutExtension(filePath);
+            PssgTreeView.ItemsSource = null;
+            TexturesListBox.ItemsSource = null;
             var tex = new PSSGNode("TEXTURE");
             tex.Attributes["id"] = EncodeString(id);
             tex.Attributes["width"] = ToBigEndian(info.Value.width);
@@ -356,6 +361,7 @@ namespace PSSGEditor
             lib.Children.Add(tex);
 
             textureEntries.Add(new TextureEntry { Name = id, Node = tex });
+            PopulateTreeView();
             PopulateTextureList();
         }
     }


### PR DESCRIPTION
## Summary
- refresh the tree view when textures are added or removed
- clear the TreeView `ItemsSource` before modifying texture nodes so the container generator stays in sync

## Testing
- `dotnet build 'PSSG Editor/PSSG Editor.csproj' -clp:ErrorsOnly` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68458d6530648325b73533090f96f970