### PR TITLE
Fix missing attributes when adding textures

### DIFF
--- a/PSSG Editor/MainWindow.TextureHandlers.cs
+++ b/PSSG Editor/MainWindow.TextureHandlers.cs
@@ -348,6 +348,18 @@ namespace PSSGEditor
             tex.Attributes["height"] = ToBigEndian(info.Value.height);
             tex.Attributes["texelFormat"] = EncodeString(info.Value.format);
             tex.Attributes["numberMipMapLevels"] = ToBigEndian(info.Value.mipMaps);
+            tex.Attributes["minFilter"] = ToBigEndian((uint)5);
+            tex.Attributes["wrapS"] = ToBigEndian((uint)1);
+            tex.Attributes["wrapT"] = ToBigEndian((uint)1);
+            tex.Attributes["wrapR"] = ToBigEndian((uint)1);
+            tex.Attributes["imageBlockCount"] = ToBigEndian((uint)1);
+            tex.Attributes["magFilter"] = ToBigEndian((uint)1);
+            tex.Attributes["gammaRemapR"] = ToBigEndian((uint)0);
+            tex.Attributes["gammaRemapG"] = ToBigEndian((uint)0);
+            tex.Attributes["gammaRemapB"] = ToBigEndian((uint)0);
+            tex.Attributes["gammaRemapA"] = ToBigEndian((uint)0);
+            tex.Attributes["automipmap"] = ToBigEndian((uint)0);
+            tex.Attributes["transient"] = ToBigEndian((uint)0);
 
             var block = new PSSGNode("TEXTUREIMAGEBLOCK");
             block.Attributes["typename"] = EncodeString("Raw");


### PR DESCRIPTION
## Summary
- fill out all required texture attributes when creating new TEXTURE nodes

## Testing
- `dotnet build DumpTextures/DumpTextures.csproj`
- `dotnet build 'PSSG Editor/PSSG Editor.csproj' -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a0e7e8e88325945e42dd67dbb09f